### PR TITLE
chore: overhaul CI/CD pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,5 @@
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    # Allow up to 10 open pull requests for npm dependencies
-    open-pull-requests-limit: 10
-
-  # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,6 @@
 <!-- Describe your changes in detail -->
 
 ## Type of change
-<!-- What type of change does your code introduce? -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
@@ -10,15 +9,15 @@
 - [ ] Refactoring (no functional changes)
 
 ## How has this been tested?
-<!-- Please describe the tests that you ran to verify your changes -->
+<!-- Describe manual verification steps performed -->
 
 ## Checklist
 - [ ] My code follows the project's style guidelines
 - [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
+- [ ] My changes generate no new compiler warnings
+- [ ] Manual verification completed per the [testing checklist](../.github/instructions/testing-strategies.instructions.md)
+- [ ] `/review` was run and issues addressed
+- [ ] New and existing tests pass locally (`cd build && ctest --output-on-failure`)
 
 ## Additional notes
 <!-- Any additional information or context -->

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "schedule": ["before 4am on Monday"],
-  "timezone": "America/New_York"
-}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,34 +2,69 @@ name: CI
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ develop ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ develop ]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v6
-    
+    - uses: actions/checkout@v4
+
+    - name: Cache apt packages
+      uses: actions/cache@v4
+      with:
+        path: /var/cache/apt/archives
+        key: apt-qt6-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential cmake qtbase5-dev libgtk-3-dev
-    
+        sudo apt-get install -y --no-install-recommends \
+          build-essential \
+          cmake \
+          qt6-base-dev \
+          libqt6sql6 \
+          libqt6sql6-sqlite \
+          libarchive-dev
+
+    - name: Cache CMake build directory
+      uses: actions/cache@v4
+      with:
+        path: build
+        key: cmake-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'src/**') }}
+        restore-keys: cmake-${{ runner.os }}-
+
     - name: Configure build
       run: |
-        mkdir build
-        cd build
-        cmake ..
-    
+        mkdir -p build && cd build && cmake \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" \
+          ..
+
     - name: Build project
-      run: |
-        cd build
-        make -j$(nproc)
-    
-    - name: Run tests (if available)
-      run: |
-        cd build
-        ctest --output-on-failure || echo "No tests found"
+      run: cd build && make -j$(nproc)
+
+    - name: Run sanity tests
+      run: cd build && ctest -L sanity -j$(nproc) --output-on-failure
+
+    - name: Run remaining tests
+      run: cd build && ctest -LE sanity -j$(nproc) --output-on-failure
+
+    - name: Upload build artifact
+      if: success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: bookhub-${{ github.sha }}
+        path: build/bookhub
+        retention-days: 7

--- a/src/collector/book_discovery_service.cpp
+++ b/src/collector/book_discovery_service.cpp
@@ -95,9 +95,7 @@ void BookDiscoveryService::insertBookIntoDatabase(const DiscoveredBook& book, co
 
     // Phase 1 — deduplicate: find an existing book that shares any of the incoming identifiers
     if (!book.identifiers.isEmpty()) {
-        QStringList clauses;
-        for (const auto& id : book.identifiers)
-            clauses << "(type = ? AND value = ?)";
+        QStringList clauses(book.identifiers.size(), QStringLiteral("(type = ? AND value = ?)"));
         QString sql = "SELECT book_id FROM book_identifiers WHERE " + clauses.join(" OR ") + " LIMIT 1";
         query.prepare(sql);
         for (const auto& id : book.identifiers) {

--- a/src/collector/book_discovery_service.h
+++ b/src/collector/book_discovery_service.h
@@ -4,6 +4,8 @@
 #include <QList>
 #include "source_adapter.h"
 
+class BookDiscoveryServiceTest; // test friend — defined in tests/integration/
+
 namespace bookhub::collector {
 
 class BookDiscoveryService : public QObject {

--- a/src/collector/book_discovery_service.h
+++ b/src/collector/book_discovery_service.h
@@ -24,7 +24,7 @@ private slots:
     void onFetchCompleted(bool success, const QString& errorMessage);
 
 private:
-    friend class BookDiscoveryServiceTest;
+    friend class ::BookDiscoveryServiceTest;
 
     void insertBookIntoDatabase(const DiscoveredBook& book, const QString& sourceName);
 


### PR DESCRIPTION
## Summary

- Fix broken CI: wrong branch targets, nonexistent `actions/checkout@v6`, Qt5 deps instead of Qt6, missing `libqt6sql6-sqlite` (caused silent database test failures under `--no-install-recommends`)
- Add pipeline hardening: `permissions: contents: read`, `concurrency` group, `timeout-minutes`, pinned `ubuntu-24.04`
- Enable `-Wall -Wextra -Werror` and `CMAKE_BUILD_TYPE=RelWithDebInfo`
- Split test execution into sanity gate (`ctest -L sanity`) then remainder (`ctest -LE sanity`), both with `-j$(nproc)`
- Cache apt packages and CMake build directory for faster runs
- Upload `bookhub` binary as a CI artifact (7-day retention)
- Remove `renovate.json` — Dependabot already covers `github-actions`; having both caused duplicate PRs
- Fix `dependabot.yml`: remove npm ecosystem (no `package.json` in repo)
- Update PR template: remove "commented my code" item (conflicts with project no-comments convention), add testing checklist and `/review` references

## Test plan

- [ ] CI run passes on this PR (build, sanity tests, full test suite)
- [ ] Verify `libqt6sql6-sqlite` resolves the QSQLITE driver in CI logs
- [ ] Confirm no duplicate Dependabot/Renovate PRs appear after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)