### PR TITLE
fix: post-Task 8 review fixes, test suite, and shutdown crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ example.json
 # Task files (migrated to GitHub Issues)
 docs/tasks/
 
+# Reviews directory
+reviews/
+
 # IDE and editor
 .vscode/
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,10 @@ make -j$(nproc)
 
 **Dependencies:**
 ```bash
-sudo apt-get install build-essential cmake qt6-base-dev libqt6sql6
+sudo apt-get install build-essential cmake qt6-base-dev libqt6sql6 libarchive-dev
 ```
 
-Requires C++23, GCC 13+/Clang 16+, and Qt6 (Widgets, Sql, Network modules). The `tar` binary must be present at runtime (used by the Gutenberg adapter via `QProcess`).
+Requires C++23, GCC 13+/Clang 16+, Qt6 (Widgets, Sql, Network modules), and libarchive (used by the Gutenberg adapter for in-process `.tar.bz2` extraction).
 
 ## Testing & Linting
 
@@ -51,7 +51,7 @@ Both threads share a single SQLite database (`bookhub.db`, placed next to the ex
 
 `ISourceAdapter` (pure abstract `QObject`) defines the interface for all book metadata sources. New sources implement it and register with `BookDiscoveryService::addAdapter()`. Currently only `GutenbergAdapter` is implemented.
 
-`GutenbergAdapter` downloads `rdf-files.tar.bz2` from Gutenberg, extracts it via a `tar` subprocess, and parses the RDF/XML files. It uses `If-Modified-Since` HTTP caching (stored in `QSettings`) to skip re-downloads. Books are emitted in batches of 500 via the `booksDiscovered` signal to bound memory usage.
+`GutenbergAdapter` downloads `rdf-files.tar.bz2` from Gutenberg, extracts it in-process via libarchive, and parses the RDF/XML files. It uses `If-Modified-Since` HTTP caching (stored in `QSettings`) to skip re-downloads. Books are emitted in batches of 500 via the `booksDiscovered` signal to bound memory usage.
 
 `BookDiscoveryService` orchestrates adapters and writes discovered books to the database in those same 500-book batches.
 
@@ -76,11 +76,11 @@ Full ID model: `docs/design/book-identity-model.md`. Schema DDL: `src/shared/dat
 - **Namespaces:** All code lives under `bookhub::`, with sub-namespaces `bookhub::db`, `bookhub::collector`, and `bookhub::gui`.
 - **Shutdown coordination:** Uses `std::atomic_bool` flags (`m_shutdownRequested`, `m_updateInProgress`) and a mix of `Qt::QueuedConnection` / `Qt::DirectConnection` for safe cross-thread teardown.
 - **Comments:** Explain *why*, not *what*. Use tags: `TODO:`, `FIXME:`, `HACK:`, `NOTE:`, `WARNING:`, `PERF:`, `SECURITY:`.
-- **Git workflow:** Every piece of work — feature, bugfix, or chore — gets its own short-lived branch cut from `develop` (e.g. `feature/task-7-search-screen`, `fix/collector-crash`, `chore/update-deps`). Keep branches small and focused: one task per branch. Merge back to `develop` via PR; never commit directly to `develop` or `master`. Both branches are protected and require PRs (0 approvals — bump to 1 in GitHub settings when a second contributor joins).
+- **Git workflow:** Every piece of work — feature, bugfix, or chore — gets its own short-lived branch cut from `develop` (e.g. `feature/task-7-search-screen`, `fix/collector-crash`, `chore/update-deps`). Keep branches small and focused: one task per branch. Merge back to `develop` via PR; never commit directly to `develop` or `master`. Both branches are protected and require PRs (0 approvals — bump to 1 in GitHub settings when a second contributor joins). **Before creating a PR, always run `/review` to perform a code review of the branch changes and address any issues found.**
 - **Build artifacts:** The icon and database are co-located with the executable via a CMake `POST_BUILD` copy. The `build/` directory is git-ignored.
 - **Docs:** When changing a public API, adding a feature, or altering architecture, update the relevant files in `docs/`. The `docs/` directory is for internal use and will be removed before release.
 - **License:** All third-party dependencies must be MIT, BSD, Apache 2.0, or similarly permissive. GPL and LGPL dependencies are forbidden — they would force the application to be GPL-licensed. Always verify a library's license before adding it. TTS uses [Sherpa-ONNX](https://github.com/k2-fsa/sherpa-onnx) (Apache 2.0) for preset voices and [PocketTTS.cpp](https://github.com/VolgaGerm/PocketTTS.cpp) (MIT) for custom voice cloning. Do not introduce the Piper GPL fork (`OHF-Voice/piper1-gpl`).
-- **QProcess:** Minimise use of `QProcess`. It is currently used only for the `tar` subprocess in `GutenbergAdapter` and must not be introduced elsewhere without a compelling reason. Prefer linking against libraries directly, using Qt's networking/IO APIs, or `QThread`/`QThreadPool` for background work.
+- **QProcess:** Do not use `QProcess` anywhere in the codebase. The earlier `tar` subprocess in `GutenbergAdapter` was replaced with a direct libarchive link. Prefer linking against libraries directly, using Qt's networking/IO APIs, or `QThread`/`QThreadPool` for background work.
 
 ## Custom Commands
 
@@ -102,6 +102,6 @@ Project-specific slash commands live in `.claude/commands/`:
 
 ### Current Status
 
-Tasks 1–5 complete: project scaffolding, SQLite schema, single-executable build, background collector with Gutenberg adapter, application icon.
+Tasks 1–8 complete: project scaffolding, SQLite schema, single-executable build, background collector with Gutenberg adapter, application icon, Library screen, Search screen, Explore screen.
 
-Tasks 6–17 not started: all GUI screens (Library, Search, Explore, Book Details), library management, download flow, audiobook/TTS conversion, additional adapters, and packaging.
+Tasks 9–17 not started: Book Details screen, library management, download flow, audiobook/TTS conversion, additional source adapters, UI polish, and packaging.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,35 +10,45 @@ set(CMAKE_AUTOUIC ON)
 
 # Ubuntu/Debian Qt6 install path fallback
 list(APPEND CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/cmake")
-find_package(Qt6 COMPONENTS Widgets Sql Network REQUIRED)
+find_package(Qt6 COMPONENTS Widgets Sql Network Test REQUIRED)
 find_package(LibArchive REQUIRED)
 
+# shared: pure database helpers, no Q_OBJECT — safe as a STATIC library consumed by all targets.
 add_library(shared STATIC
     src/shared/database.cpp
 )
 target_include_directories(shared PUBLIC src/shared)
-target_link_libraries(shared PUBLIC Qt6::Sql Qt6::Network)
+target_link_libraries(shared PUBLIC Qt6::Sql)
 
-add_executable(bookhub
-    src/main.cpp
+# Collector and GUI sources are compiled directly into the consuming target rather than as a
+# separate STATIC library. Qt AUTOMOC + STATIC libraries causes CMake to recompile all sources
+# inline for every consumer while also omitting the library's moc_compilation unit from the
+# link, leaving Q_OBJECT vtables/staticMetaObjects undefined at link time.
+set(COLLECTOR_SOURCES
     src/collector/collector_worker.cpp
     src/collector/source_adapter.cpp
     src/collector/gutenberg_adapter.cpp
     src/collector/book_discovery_service.cpp
-    # GUI — Task 6: Library Screen
+)
+
+set(GUI_SOURCES
     src/gui/main_window.cpp
     src/gui/screens/library_screen.cpp
     src/gui/widgets/book_card_delegate.cpp
     src/gui/widgets/empty_state_widget.cpp
     src/gui/widgets/badge_label.cpp
-    src/gui/services/library_service.cpp
-    # GUI — Task 7: Search Screen
     src/gui/screens/search_screen.cpp
     src/gui/widgets/search_result_delegate.cpp
+    src/gui/services/library_service.cpp
     src/gui/services/search_service.cpp
-    # GUI — Task 8: Explore Screen
     src/gui/screens/explore_screen.cpp
     src/gui/services/explore_service.cpp
+)
+
+add_executable(bookhub
+    src/main.cpp
+    ${COLLECTOR_SOURCES}
+    ${GUI_SOURCES}
 )
 target_include_directories(bookhub PRIVATE src)
 target_link_libraries(bookhub PRIVATE Qt6::Widgets Qt6::Network shared LibArchive::LibArchive)
@@ -50,3 +60,69 @@ add_custom_command(TARGET bookhub POST_BUILD
         "$<TARGET_FILE_DIR:bookhub>/book_reader_icon.jpg"
     COMMENT "Copying book_reader_icon.jpg next to executable"
 )
+
+enable_testing()
+
+function(add_bookhub_test test_name)
+    add_executable(${test_name} ${ARGN} ${COLLECTOR_SOURCES} ${GUI_SOURCES})
+    target_include_directories(${test_name} PRIVATE src tests)
+    target_link_libraries(${test_name} PRIVATE Qt6::Test Qt6::Widgets Qt6::Network shared LibArchive::LibArchive)
+    add_test(NAME ${test_name} COMMAND ${test_name})
+    set_tests_properties(${test_name} PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    )
+endfunction()
+
+function(label_bookhub_test test_name)
+    set_property(TEST ${test_name} APPEND PROPERTY LABELS ${ARGN})
+endfunction()
+
+add_bookhub_test(test_database_schema
+    tests/unit/test_database_schema.cpp
+)
+label_bookhub_test(test_database_schema sanity unit database)
+
+add_bookhub_test(test_gutenberg_id_resolution
+    tests/unit/test_gutenberg_id_resolution.cpp
+)
+label_bookhub_test(test_gutenberg_id_resolution sanity unit collector identity)
+
+add_bookhub_test(test_book_discovery_service
+    tests/integration/test_book_discovery_service.cpp
+)
+label_bookhub_test(test_book_discovery_service sanity integration collector identity)
+
+add_bookhub_test(test_library_service
+    tests/integration/test_library_service.cpp
+)
+label_bookhub_test(test_library_service sanity integration library)
+
+add_bookhub_test(test_main_window
+    tests/gui/test_main_window.cpp
+)
+label_bookhub_test(test_main_window sanity gui shell)
+
+add_bookhub_test(test_library_screen
+    tests/gui/test_library_screen.cpp
+)
+label_bookhub_test(test_library_screen gui library)
+
+add_bookhub_test(test_search_service
+    tests/integration/test_search_service.cpp
+)
+label_bookhub_test(test_search_service integration search)
+
+add_bookhub_test(test_search_screen
+    tests/gui/test_search_screen.cpp
+)
+label_bookhub_test(test_search_screen gui search)
+
+add_bookhub_test(test_explore_service
+    tests/integration/test_explore_service.cpp
+)
+label_bookhub_test(test_explore_service integration explore)
+
+add_bookhub_test(test_explore_screen
+    tests/gui/test_explore_screen.cpp
+)
+label_bookhub_test(test_explore_screen gui explore)

--- a/docs/design/classic-books-architecture.drawio
+++ b/docs/design/classic-books-architecture.drawio
@@ -29,7 +29,7 @@
           <mxGeometry x="300" y="50" width="80" height="60" as="geometry"/>
         </mxCell>
 
-        <mxCell id="book-details" value="BookDetailsScreen" style="whiteSpace=wrap;html=1;" vertex="1" parent="gui-process">
+        <mxCell id="book-details" value="BookDetailsPanel" style="whiteSpace=wrap;html=1;" vertex="1" parent="gui-process">
           <mxGeometry x="20" y="130" width="120" height="60" as="geometry"/>
         </mxCell>
 

--- a/docs/design/classic-books-audiobook-hub-design.md
+++ b/docs/design/classic-books-audiobook-hub-design.md
@@ -20,10 +20,10 @@
 
 ### 3.1 Overall approach
 
-Build a single native C++ application (one program) utilizing **two separate threads/processes**:
+Build a single native C++ application (one program) utilizing **two separate threads**:
 
-1. **GUI Thread/Process**: Runs the Qt desktop interface (Library, Search, Explore, BookDetails, Download/Audiobook flows). Reads from the shared SQLite database and handles user interactions.
-2. **Data Collector Thread/Process**: Runs in the background and periodically refreshes book metadata from sources (Gutenberg, Ben-Yehuda, etc.). Updates the SQLite database on a configurable schedule.
+1. **GUI Thread**: Runs the Qt desktop interface (Library, Search, Explore, BookDetailsPanel, Download/Audiobook flows). Reads from the shared SQLite database and handles user interactions.
+2. **Data Collector Thread**: Runs in the background and periodically refreshes book metadata from sources (Gutenberg, Ben-Yehuda, etc.). Updates the SQLite database on a configurable schedule.
 
 This single-program architecture keeps the GUI responsive, separates concerns, and enables user-configurable update frequency.
 
@@ -127,8 +127,8 @@ This is exactly what relational databases are designed for—efficient storage a
    - Category cards, subcategory drill-down, discovery sections: trending, new arrivals, curated.
    - Reads from cached category and book data in the database.
 
-4. `BookDetailsScreen`
-   - Full metadata view and availability by edition.
+4. `BookDetailsPanel`
+   - Full metadata view and availability by edition, shown as a right-side split pane (50/50 `QSplitter`) within the active screen — not a separate window.
    - Queries the database for Edition and Format records.
    - Controls for add-to-library, download, audiobook conversion.
    - Language selector when multiple editions exist.
@@ -136,8 +136,7 @@ This is exactly what relational databases are designed for—efficient storage a
 5. `DownloadFlow`
    - Step 1: select language edition.
    - Step 2: choose ebook format.
-   - Step 3: choose source.
-   - Step 4: confirm download.
+   - Step 3: choose source and confirm download.
 
 6. `AudiobookFlow`
    - Step 1: select language edition.
@@ -407,7 +406,7 @@ The architecture has three main layers:
 
 1. **UI layer**
    - Qt application (Qt Quick or Qt Widgets)
-   - Screens: Library, Search, Explore, BookDetails, DownloadFlow, AudiobookFlow
+   - Screens: Library, Search, Explore, BookDetailsPanel (split-pane), DownloadFlow, AudiobookFlow
    - Directly interacts with C++ application services
 
 2. **Application layer**
@@ -437,7 +436,7 @@ This separation keeps the UI responsive, the business logic centralized in C++, 
 1. Define SQLite database schema for Book, Edition, Source, Format, LibraryItem, and Voice entities.
 2. Implement the first source adapter (e.g., Gutenberg) to fetch and normalize book metadata.
 3. Build the data collector background thread with configurable update schedule.
-4. Build the GUI components with Qt and implement Library and BookDetails screens first.
+4. Build the GUI components with Qt and implement Library and BookDetailsPanel first.
 5. Implement Search and Explore screens once the core metadata queries are stable.
 6. Add Download flow and Audiobook flow after the core discovery experience is working.
 7. Implement voice preview and generation as the final MVP phase.

--- a/docs/design/gui-design-spec.md
+++ b/docs/design/gui-design-spec.md
@@ -59,7 +59,7 @@ graph TD
   ScreenStack --> SearchScreen
   ScreenStack --> ExploreScreen
 
-  LibraryScreen --> BookDetailsPanel["BookDetailsPanel (QDockWidget or right-pane)"]
+  LibraryScreen --> BookDetailsPanel["BookDetailsPanel (QSplitter right pane)"]
   SearchScreen --> BookDetailsPanel
   ExploreScreen --> BookDetailsPanel
 
@@ -227,7 +227,7 @@ Each row is 96 px tall (list mode) or a 200 × 260 px card (grid mode). The two 
 **Accessibility:**
 - Each book card announces "Title by Author. Status: downloaded. Language: English." via `QAccessibleWidget`
 - Tab order: Sort combo → list → (within card: Details → Download/Audiobook → Remove)
-- Remove button has tooltip: "Remove from library"
+- All library card action buttons have descriptive tooltips: "View book details" (Details), "Download this book" (Download), "Convert to audiobook" (Audiobook), "Remove from library" (Remove).
 
 ---
 
@@ -341,6 +341,7 @@ graph TD
 - Search triggers on Enter key press in the search bar or after 500 ms debounce.
 - Active filters are combined with AND logic (all conditions must match).
 - Results are paginated: 50 rows per page; "Load more" appends next page to the list model.
+- **Pagination stability (MVP):** The collector may insert new rows between "Load more" page loads. This can cause occasional duplicate or shifted results. This is an accepted MVP limitation — no cursor-based stabilisation is required.
 - Result count label updates with each query ("247 books", "No results").
 
 **Search Result Card (delegate rendered row):** 72 px tall.
@@ -694,7 +695,7 @@ Each format type (`epub`, `pdf`, `txt`, `html`) renders one row:
 │  [████████████████░░░░░░░░░░░░]  54%       │
 │  1.2 MB / 2.3 MB                           │
 │                                            │
-│  Saving to: ~/Books/                       │
+│  Saving to: ~/Downloads/                   │
 │                                [Cancel]    │
 └────────────────────────────────────────────┘
 ```
@@ -750,7 +751,7 @@ graph TD
 **Download Behaviour:**
 - Initiated by `QNetworkAccessManager::get()` on the GUI thread.
 - Progress signals update `QProgressBar` via lambda.
-- File saved to a user-configurable directory (default: `~/Books/`; stored in `QSettings`).
+- File saved to a directory chosen via `QFileDialog` (pre-seeded with last-used path, defaulting to `QDir::homePath()` on first use; chosen path stored in `QSettings`). There is no separate settings screen — the dialog itself is the only place the directory is chosen.
 - On completion: dialog shows "Download complete" with "Open file" and "Close" buttons.
 - On error: inline error message with "Retry" button.
 

--- a/docs/design/sanity-check-test-tier.md
+++ b/docs/design/sanity-check-test-tier.md
@@ -1,0 +1,239 @@
+# Design: Sanity Check Test Tier
+
+## Purpose
+
+BookHub now has enough automated coverage that we should split CI into two test tiers:
+
+- `sanity check`: fast, high-signal verification for pull requests into `develop`
+- `full suite`: complete automated verification for pull requests into `master`
+
+The goal is to keep `develop` feedback fast while still protecting the highest-risk paths, and to keep `master` protected by the full regression suite.
+
+---
+
+## Proposed CI Policy
+
+### PR to `develop`
+
+Run only the `sanity check` tier.
+
+This tier should:
+
+- finish quickly
+- cover core database and identity rules
+- cover one smoke-level path for the main GUI shell
+- avoid broad widget permutations, pagination-heavy tests, and slower event-loop-heavy scenarios unless they catch a critical regression class
+
+### PR to `master`
+
+Run the full automated test suite.
+
+This tier should:
+
+- include every `sanity check` test
+- include all service, integration, and GUI behavior tests
+- serve as the release-quality regression gate
+
+---
+
+## Selection Rules
+
+A test belongs in the `sanity check` tier if it satisfies most of these:
+
+- it protects a core architectural invariant
+- it catches high-severity regressions
+- it is deterministic in headless CI
+- it is fast to execute
+- it does not depend on unfinished UI
+- it gives broad confidence relative to its runtime cost
+
+A test should stay out of the `sanity check` tier if it is primarily:
+
+- a detailed widget behavior test
+- a pagination/debounce/timer-heavy scenario
+- a wide combinatorial filter test
+- a design-acceptance test for non-critical UX details
+- a test for future or partial functionality
+
+---
+
+## Proposed Sanity Check Scope
+
+These are the initial tests that should make up the `sanity check` group.
+
+### 1. Database and schema smoke
+
+- test target: `test_database_schema`
+- why it belongs:
+  - validates schema creation
+  - validates schema version checks
+  - validates uniqueness and cascade behavior
+  - catches the most damaging database regressions early
+
+### 2. Gutenberg identifier resolution smoke
+
+- test target: `test_gutenberg_id_resolution`
+- why it belongs:
+  - validates canonical identifier resolution
+  - protects LCCN normalization and fallback behavior
+  - covers one of the most fragile data-normalization paths
+
+### 3. Discovery deduplication and promotion smoke
+
+- test target: `test_book_discovery_service`
+- why it belongs:
+  - validates insertion, deduplication, and stronger-ID promotion
+  - protects the book identity model, which is a central project risk
+
+### 4. Library service smoke
+
+- test target: `test_library_service`
+- why it belongs:
+  - validates add/remove/update operations
+  - ensures core user-library persistence still works
+
+### 5. Main window shell smoke
+
+- test target: `test_main_window`
+- why it belongs:
+  - validates application shell construction
+  - validates core navigation
+  - provides a cheap top-level GUI smoke test
+
+---
+
+## Tests Excluded From Sanity Check
+
+These should still run in the full suite, but not in the initial `develop` gate.
+
+### Full-suite only for now
+
+- `test_library_screen`
+- `test_search_service`
+- `test_search_screen`
+- `test_explore_service`
+- `test_explore_screen`
+
+### Why they are excluded
+
+- they test broader feature behavior rather than minimal platform health
+- some are more UI-interaction-heavy than necessary for a fast `develop` gate
+- some cover secondary workflows rather than the most critical invariants
+
+This does not mean they are low value. It only means they are better suited to the full regression gate on `master`.
+
+---
+
+## Growth Rules
+
+We should add a test to `sanity check` only if one of these becomes true:
+
+- a regression escaped because the full suite ran too late
+- the test repeatedly catches real breakages in core workflows
+- the runtime cost stays low while confidence gain is high
+
+We should remove a test from `sanity check` if:
+
+- it becomes flaky in CI
+- its runtime grows noticeably
+- it duplicates confidence already provided by another cheaper test
+
+---
+
+## Mapping To Current Test Tasks
+
+Included in `sanity check`:
+
+- Test Task 1: Database and schema integrity tests
+- Test Task 2: Gutenberg identifier resolution tests
+- Test Task 3: Book discovery deduplication and promotion tests
+- Test Task 4: Library service tests
+- Test Task 6: Main window shell and navigation tests
+
+Full-suite only:
+
+- Test Task 5: Library screen GUI tests
+- Test Task 7: Search service tests
+- Test Task 8: Search screen GUI tests
+- Test Task 9: Explore service tests
+- Test Task 10: Explore screen GUI tests
+- Test Task 11+: partial and blocked buckets
+
+---
+
+## Recommended Naming
+
+Use these names consistently in code and CI:
+
+- `sanity`: the fast `develop` PR gate
+- `full`: the complete `master` PR gate
+
+Avoid names like `smoke`, `quick`, or `basic` unless we intentionally want a third tier later.
+
+---
+
+## Future Implementation Notes
+
+When we wire this into CMake/CTest or CI, the simplest shape is:
+
+- one label or grouping mechanism for `sanity`
+- one full run that executes all tests
+
+The `full` tier should not be a separately maintained list if we can avoid it. Prefer:
+
+- `sanity` = explicit subset
+- `full` = everything
+
+That keeps maintenance low and avoids forgetting to add new tests to the full suite.
+
+---
+
+## Current Runner Integration
+
+The CMake/CTest suite now labels the sanity-check tests with the `sanity` label.
+
+### Local commands
+
+Run the sanity tier only:
+
+```bash
+ctest --test-dir build -L sanity --output-on-failure
+```
+
+Run the full suite:
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+List all sanity tests:
+
+```bash
+ctest --test-dir build -N -L sanity
+```
+
+### Current sanity-labeled tests
+
+- `test_database_schema`
+- `test_gutenberg_id_resolution`
+- `test_book_discovery_service`
+- `test_library_service`
+- `test_main_window`
+
+### CI mapping
+
+Suggested `develop` gate:
+
+```bash
+cmake -S . -B build
+cmake --build build -j4
+ctest --test-dir build -L sanity --output-on-failure
+```
+
+Suggested `master` gate:
+
+```bash
+cmake -S . -B build
+cmake --build build -j4
+ctest --test-dir build --output-on-failure
+```

--- a/docs/design/test-strategy.md
+++ b/docs/design/test-strategy.md
@@ -186,12 +186,75 @@ Representative scenarios:
 4. two editions with same `book_id` but different languages
 5. duplicate identifier insertion on a second collector run
 
+### `SearchService`
+
+- Keyword containing `%` or `_` is escaped before being passed to the `LIKE` clause, so it matches
+  literal characters rather than SQL wildcards.
+- Empty keyword with no filters returns all books (or zero, whichever the service defines as the
+  intended contract — document this explicitly in the test).
+- AND semantics hold across all active filters simultaneously.
+
 ### Library/database integration
 
 - Adding a library item makes it appear in the library query.
 - Removing a book cleans up dependent library rows safely.
 - Audiobook-ready status is queryable for search filters.
 - Distinct languages, formats, and source lists are returned correctly for details/search views.
+
+---
+
+## Test Implementation Quality Rules
+
+These rules apply to every test in this suite. They exist because several fragility patterns appeared
+during early implementation and are easy to repeat.
+
+### Never hardcode database row IDs
+
+Row IDs from `autoincrement` columns depend on insertion order and are not stable across sample data
+changes. Always query for the ID after the row is inserted:
+
+```cpp
+// Wrong
+service.addBook("gutenberg:1184", 4);
+
+// Right
+const int editionId = testDb.scalarInt("SELECT id FROM editions WHERE book_id = 'gutenberg:1184'");
+service.addBook("gutenberg:1184", editionId);
+```
+
+### Never use a whitespace string as a wildcard keyword
+
+Using `keyword = " "` to retrieve all results is fragile: if the service trims whitespace before
+querying, it returns zero results, and an assertion like `QVERIFY(results.size() >= N)` passes
+vacuously. Use `SearchParams{}` with no keyword to express "no filter", or test the empty-keyword
+contract explicitly with `QCOMPARE`.
+
+### Avoid `QTest::qWait` for debounce timing
+
+`QTest::qWait(550)` is slow and flaky on loaded CI runners. Prefer one of:
+
+- Make the debounce delay configurable and set it to 0 in tests.
+- Expose a `triggerSearch()` slot that bypasses the debounce timer entirely.
+- Use `QSignalSpy::wait()` with a generous timeout instead of a fixed sleep.
+
+### Avoid short timers to accept modal dialogs
+
+A `QTimer` with a 10ms interval fires before the dialog renders on a slow machine. Use
+`QTimer::singleShot(0, ...)` plus `QCoreApplication::processEvents()` after the action, or
+spy on the dialog's `finished` signal directly.
+
+### Document non-obvious ordering assertions
+
+If a test asserts a specific item at position 0, add a comment explaining the invariant that
+produces that order. Assertions like `QCOMPARE(trending.first().bookId, "book:25")` with no
+explanation are opaque and break silently when query ordering changes.
+
+### Clarify fresh-database contracts
+
+`verifySchemaVersion` returning `true` for an empty database is only correct if the production
+code defines an empty database as fresh-and-valid. Wherever this contract is tested, name the
+test `freshDatabase_isValid` and `versionMismatch_isInvalid` as separate cases with a comment
+stating the intended invariant.
 
 ---
 

--- a/docs/design/test-strategy.md
+++ b/docs/design/test-strategy.md
@@ -190,8 +190,8 @@ Representative scenarios:
 
 - Keyword containing `%` or `_` is escaped before being passed to the `LIKE` clause, so it matches
   literal characters rather than SQL wildcards.
-- Empty keyword with no filters returns all books (or zero, whichever the service defines as the
-  intended contract — document this explicitly in the test).
+- Empty keyword with no filters returns all books. `SearchParams{}` is a no-filter query and must
+  return every row in the database; test with `QCOMPARE(results.size(), totalBooks)`.
 - AND semantics hold across all active filters simultaneously.
 
 ### Library/database integration

--- a/src/collector/book_discovery_service.cpp
+++ b/src/collector/book_discovery_service.cpp
@@ -19,6 +19,11 @@ void BookDiscoveryService::addAdapter(ISourceAdapter* adapter) {
 }
 
 void BookDiscoveryService::startDiscovery() {
+    if (m_activeFetches > 0) {
+        qDebug() << "BookDiscoveryService: Discovery already in progress; skipping overlapping run.";
+        return;
+    }
+
     qDebug() << "BookDiscoveryService: Starting discovery across" << m_adapters.size() << "adapters.";
     if (m_adapters.isEmpty()) {
         return;
@@ -160,19 +165,32 @@ void BookDiscoveryService::insertBookIntoDatabase(const DiscoveredBook& book, co
     const int editionId = query.value(0).toInt();
 
     for (auto it = book.formats.constBegin(); it != book.formats.constEnd(); ++it) {
-        query.prepare("INSERT INTO formats (edition_id, format_type) VALUES (?, ?)");
+        query.prepare("INSERT OR IGNORE INTO formats (edition_id, format_type) VALUES (?, ?)");
         query.addBindValue(editionId);
         query.addBindValue(it.key());
-        if (query.exec()) {
-            const int formatId = query.lastInsertId().toInt();
-            QSqlQuery sourceQuery(db);
-            sourceQuery.prepare("INSERT INTO sources (format_id, source_name, download_link) VALUES (?, ?, ?)");
-            sourceQuery.addBindValue(formatId);
-            sourceQuery.addBindValue(sourceName);
-            sourceQuery.addBindValue(it.value());
-            if (!sourceQuery.exec()) {
-                qWarning() << "Failed to insert source:" << sourceQuery.lastError().text();
-            }
+        if (!query.exec()) {
+            qWarning() << "Failed to insert format:" << query.lastError().text();
+            continue;
+        }
+
+        // Retrieve the format id whether the row was just inserted or already existed.
+        QSqlQuery fmtQuery(db);
+        fmtQuery.prepare("SELECT id FROM formats WHERE edition_id = ? AND format_type = ?");
+        fmtQuery.addBindValue(editionId);
+        fmtQuery.addBindValue(it.key());
+        if (!fmtQuery.exec() || !fmtQuery.next()) {
+            qWarning() << "Failed to retrieve format id:" << fmtQuery.lastError().text();
+            continue;
+        }
+        const int formatId = fmtQuery.value(0).toInt();
+
+        QSqlQuery sourceQuery(db);
+        sourceQuery.prepare("INSERT OR IGNORE INTO sources (format_id, source_name, download_link) VALUES (?, ?, ?)");
+        sourceQuery.addBindValue(formatId);
+        sourceQuery.addBindValue(sourceName);
+        sourceQuery.addBindValue(it.value());
+        if (!sourceQuery.exec()) {
+            qWarning() << "Failed to insert source:" << sourceQuery.lastError().text();
         }
     }
 }

--- a/src/collector/book_discovery_service.h
+++ b/src/collector/book_discovery_service.h
@@ -24,6 +24,8 @@ private slots:
     void onFetchCompleted(bool success, const QString& errorMessage);
 
 private:
+    friend class BookDiscoveryServiceTest;
+
     void insertBookIntoDatabase(const DiscoveredBook& book, const QString& sourceName);
 
     QString m_dbConnectionName;

--- a/src/collector/collector_worker.cpp
+++ b/src/collector/collector_worker.cpp
@@ -19,13 +19,14 @@ CollectorWorker::~CollectorWorker() {
 void CollectorWorker::requestShutdownAfterCurrentUpdate() {
     m_shutdownRequested.store(true);
 
-    if (!isRunning() || !m_threadContext) {
+    QObject* ctx = m_threadContext.load();
+    if (!isRunning() || !ctx) {
         return;
     }
 
     // Post into the collector thread's event loop so m_discoveryService and
     // m_pollTimer are only touched from the thread that owns them.
-    QMetaObject::invokeMethod(m_threadContext, [this]() {
+    QMetaObject::invokeMethod(ctx, [this]() {
         if (m_pollTimer)
             m_pollTimer->stop();
 
@@ -38,13 +39,13 @@ void CollectorWorker::run() {
     qDebug() << "Data collector background thread started.";
 
     QObject threadContext;
-    m_threadContext = &threadContext;
+    m_threadContext.store(&threadContext);
 
     // 1. Initialize thread-local database connection
     QString connectionName = "collector_connection";
     if (!bookhub::db::initializeDatabase(bookhub::db::databaseFilePath(), connectionName)) {
         qWarning() << "Collector thread failed to initialize database.";
-        m_threadContext = nullptr;
+        m_threadContext.store(nullptr);
         return;
     }
 
@@ -86,7 +87,7 @@ void CollectorWorker::run() {
     exec();
 
     m_pollTimer = nullptr;
-    m_threadContext = nullptr;
+    m_threadContext.store(nullptr);
     m_discoveryService = nullptr;
     qDebug() << "Data collector background thread stopped.";
 }

--- a/src/collector/collector_worker.cpp
+++ b/src/collector/collector_worker.cpp
@@ -19,9 +19,13 @@ CollectorWorker::~CollectorWorker() {
 void CollectorWorker::requestShutdownAfterCurrentUpdate() {
     m_shutdownRequested.store(true);
 
+    if (!isRunning() || !m_threadContext) {
+        return;
+    }
+
     // Post into the collector thread's event loop so m_discoveryService and
     // m_pollTimer are only touched from the thread that owns them.
-    QMetaObject::invokeMethod(this, [this]() {
+    QMetaObject::invokeMethod(m_threadContext, [this]() {
         if (m_pollTimer)
             m_pollTimer->stop();
 
@@ -33,10 +37,14 @@ void CollectorWorker::requestShutdownAfterCurrentUpdate() {
 void CollectorWorker::run() {
     qDebug() << "Data collector background thread started.";
 
+    QObject threadContext;
+    m_threadContext = &threadContext;
+
     // 1. Initialize thread-local database connection
     QString connectionName = "collector_connection";
     if (!bookhub::db::initializeDatabase(bookhub::db::databaseFilePath(), connectionName)) {
         qWarning() << "Collector thread failed to initialize database.";
+        m_threadContext = nullptr;
         return;
     }
 
@@ -63,7 +71,7 @@ void CollectorWorker::run() {
 
     QTimer timer;
     m_pollTimer = &timer;
-    connect(&timer, &QTimer::timeout, this, [this]() {
+    connect(&timer, &QTimer::timeout, &threadContext, [this]() {
         if (m_shutdownRequested.load()) {
             return;
         }
@@ -78,6 +86,7 @@ void CollectorWorker::run() {
     exec();
 
     m_pollTimer = nullptr;
+    m_threadContext = nullptr;
     m_discoveryService = nullptr;
     qDebug() << "Data collector background thread stopped.";
 }

--- a/src/collector/collector_worker.cpp
+++ b/src/collector/collector_worker.cpp
@@ -19,20 +19,14 @@ CollectorWorker::~CollectorWorker() {
 void CollectorWorker::requestShutdownAfterCurrentUpdate() {
     m_shutdownRequested.store(true);
 
-    auto* discoveryService = m_discoveryService.data();
-    if (!discoveryService) {
-        quit();
-        return;
-    }
-
-    QMetaObject::invokeMethod(discoveryService, [this]() {
-        if (m_pollTimer) {
+    // Post into the collector thread's event loop so m_discoveryService and
+    // m_pollTimer are only touched from the thread that owns them.
+    QMetaObject::invokeMethod(this, [this]() {
+        if (m_pollTimer)
             m_pollTimer->stop();
-        }
 
-        if (!m_updateInProgress.load()) {
+        if (!m_updateInProgress.load())
             QThread::currentThread()->quit();
-        }
     }, Qt::QueuedConnection);
 }
 

--- a/src/collector/collector_worker.h
+++ b/src/collector/collector_worker.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QObject>
 #include <QThread>
 #include <QTimer>
 #include <atomic>
@@ -22,6 +23,7 @@ private:
     // Owned by the collector thread's run() stack frame; only accessed from
     // the collector thread except through QMetaObject::invokeMethod queued calls.
     class BookDiscoveryService* m_discoveryService{nullptr};
+    QObject* m_threadContext{nullptr};
     QTimer* m_pollTimer{nullptr};
     std::atomic_bool m_shutdownRequested{false};
     std::atomic_bool m_updateInProgress{false};

--- a/src/collector/collector_worker.h
+++ b/src/collector/collector_worker.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QPointer>
 #include <QThread>
 #include <QTimer>
 #include <atomic>
@@ -20,8 +19,10 @@ protected:
     void run() override;
 
 private:
-    QPointer<class BookDiscoveryService> m_discoveryService;
-    QPointer<QTimer> m_pollTimer;
+    // Owned by the collector thread's run() stack frame; only accessed from
+    // the collector thread except through QMetaObject::invokeMethod queued calls.
+    class BookDiscoveryService* m_discoveryService{nullptr};
+    QTimer* m_pollTimer{nullptr};
     std::atomic_bool m_shutdownRequested{false};
     std::atomic_bool m_updateInProgress{false};
 };

--- a/src/collector/collector_worker.h
+++ b/src/collector/collector_worker.h
@@ -23,7 +23,7 @@ private:
     // Owned by the collector thread's run() stack frame; only accessed from
     // the collector thread except through QMetaObject::invokeMethod queued calls.
     class BookDiscoveryService* m_discoveryService{nullptr};
-    QObject* m_threadContext{nullptr};
+    std::atomic<QObject*> m_threadContext{nullptr};
     QTimer* m_pollTimer{nullptr};
     std::atomic_bool m_shutdownRequested{false};
     std::atomic_bool m_updateInProgress{false};

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -189,11 +189,11 @@ void MainWindow::onNavTabChanged(int id, bool checked)
 void MainWindow::onLibraryExploreRequested()
 {
     // Switch to the Explore tab (index 2) when the user clicks "Explore Books"
-    // from the empty library state.
+    // from the empty library state. setChecked fires idToggled → onNavTabChanged
+    // which calls setCurrentIndex(2), so no explicit setCurrentIndex is needed.
     if (auto *btn = qobject_cast<QPushButton *>(m_navGroup->button(2))) {
         btn->setChecked(true);
     }
-    m_stack->setCurrentIndex(2);
 }
 
 } // namespace bookhub::gui

--- a/src/gui/main_window.h
+++ b/src/gui/main_window.h
@@ -17,7 +17,7 @@ class ExploreScreen;
 //
 // Layout (spec Section 1):
 //   - Dark nav bar (48 px): three exclusive QPushButton tabs
-//   - QStackedWidget: LibraryScreen (0), SearchScreen (1), placeholder (2)
+//   - QStackedWidget: LibraryScreen (0), SearchScreen (1), ExploreScreen (2)
 //   - QStatusBar (24 px): collector status text + coloured dot
 //
 // Receives CollectorWorker status signals via Qt::QueuedConnection so the

--- a/src/gui/screens/explore_screen.cpp
+++ b/src/gui/screens/explore_screen.cpp
@@ -565,8 +565,6 @@ void ExploreScreen::appendGenreBooks(int offset)
         return;
     }
 
-    // Append cards starting from the next free row
-    const int startRow = offset / kGridColumns;
     for (int i = 0; i < books.size(); ++i) {
         const ExploreBook &b = books[i];
         auto *card = new BookMiniCard(b.bookId, b.title, b.author, m_genreGridContainer);

--- a/src/gui/screens/library_screen.cpp
+++ b/src/gui/screens/library_screen.cpp
@@ -305,13 +305,14 @@ void LibraryScreen::onRemoveRequested(int libraryItemId, const QString &bookId)
         }
     }
 
-    auto *msg = new QMessageBox(this);
-    msg->setWindowTitle(QStringLiteral("Remove from library"));
-    msg->setText(QStringLiteral("Remove \"%1\" from your library?").arg(title));
-    msg->setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
-    msg->setDefaultButton(QMessageBox::Cancel);
+    const auto answer = QMessageBox::question(
+        this,
+        QStringLiteral("Remove from library"),
+        QStringLiteral("Remove \"%1\" from your library?").arg(title),
+        QMessageBox::Yes | QMessageBox::Cancel,
+        QMessageBox::Cancel);
 
-    if (msg->exec() == QMessageBox::Yes)
+    if (answer == QMessageBox::Yes)
         m_service->removeBook(libraryItemId);
 }
 

--- a/src/gui/screens/search_screen.cpp
+++ b/src/gui/screens/search_screen.cpp
@@ -22,6 +22,7 @@
 #include <QScrollArea>
 #include <QComboBox>
 #include <QFrame>
+#include <QSignalBlocker>
 #include <QToolButton>
 
 namespace bookhub::gui {
@@ -93,6 +94,11 @@ SearchScreen::SearchScreen(QWidget *parent)
             item->setHidden(true);
     }
     m_showMoreGenres->setVisible(genres.size() > kGenreCollapsed);
+    {
+        const int rowH = m_genreList->sizeHintForRow(0);
+        if (rowH > 0)
+            m_genreList->setFixedHeight(kGenreCollapsed * rowH);
+    }
 
     for (const QString &lang : languages) {
         auto *item = new QListWidgetItem(lang, m_langList);
@@ -242,7 +248,6 @@ void SearchScreen::buildFilterPanel(QWidget *panel)
     m_genreList->setStyleSheet(listStyle);
     m_genreList->setSelectionMode(QAbstractItemView::NoSelection);
     m_genreList->setFocusPolicy(Qt::NoFocus);
-    m_genreList->setFixedHeight(kGenreCollapsed * 24);
     connect(m_genreList, &QListWidget::itemChanged,
             this, &SearchScreen::onFiltersChanged);
     layout->addWidget(m_genreList);
@@ -500,8 +505,9 @@ void SearchScreen::buildResultsPane(QWidget *pane)
 SearchParams SearchScreen::collectParams() const
 {
     SearchParams p;
-    p.keyword = m_searchBar->text().trimmed();
-    p.author  = m_authorFilter->text().trimmed();
+    p.keyword    = m_searchBar->text().trimmed();
+    p.author     = m_authorFilter->text().trimmed();
+    p.sortColumn = m_currentSortColumn;
 
     for (int i = 0; i < m_genreList->count(); ++i) {
         const auto *item = m_genreList->item(i);
@@ -531,6 +537,20 @@ SearchParams SearchScreen::collectParams() const
     p.audiobookOnly = m_audiobookCheck->isChecked();
 
     return p;
+}
+
+bool SearchScreen::isQueryActive() const
+{
+    const SearchParams p = collectParams();
+    return !p.keyword.isEmpty()
+        || !p.author.isEmpty()
+        || !p.genres.isEmpty()
+        || p.yearFrom > 0
+        || p.yearTo > 0
+        || !p.languages.isEmpty()
+        || !p.sources.isEmpty()
+        || p.ebookOnly
+        || p.audiobookOnly;
 }
 
 void SearchScreen::populateModel(const QList<SearchResult> &results, bool append)
@@ -603,20 +623,7 @@ void SearchScreen::onFiltersChanged()
 
 void SearchScreen::runSearch()
 {
-    const SearchParams params = collectParams();
-
-    // If nothing is active, show the initial hint state
-    const bool hasQuery = !params.keyword.isEmpty()
-                        || !params.author.isEmpty()
-                        || !params.genres.isEmpty()
-                        || params.yearFrom > 0
-                        || params.yearTo > 0
-                        || !params.languages.isEmpty()
-                        || !params.sources.isEmpty()
-                        || params.ebookOnly
-                        || params.audiobookOnly;
-
-    if (!hasQuery) {
+    if (!isQueryActive()) {
         m_model->clear();
         m_currentOffset = 0;
         m_totalCount    = 0;
@@ -625,6 +632,8 @@ void SearchScreen::runSearch()
         setResultsState(0);
         return;
     }
+
+    const SearchParams params = collectParams();
 
     // Count query runs only when filters change (not on "Load more")
     m_totalCount = m_service->count(params);
@@ -679,13 +688,13 @@ void SearchScreen::onAddToLibrary(const QString &bookId)
 void SearchScreen::onClearFilters()
 {
     // Block signals while resetting to avoid triggering multiple re-searches.
-    m_searchBar->blockSignals(true);
-    m_authorFilter->blockSignals(true);
-    m_genreList->blockSignals(true);
-    m_langList->blockSignals(true);
-    m_srcList->blockSignals(true);
-    m_ebookCheck->blockSignals(true);
-    m_audiobookCheck->blockSignals(true);
+    const QSignalBlocker bSearchBar(m_searchBar);
+    const QSignalBlocker bAuthorFilter(m_authorFilter);
+    const QSignalBlocker bGenreList(m_genreList);
+    const QSignalBlocker bLangList(m_langList);
+    const QSignalBlocker bSrcList(m_srcList);
+    const QSignalBlocker bEbookCheck(m_ebookCheck);
+    const QSignalBlocker bAudiobookCheck(m_audiobookCheck);
 
     m_searchBar->clear();
     m_authorFilter->clear();
@@ -702,14 +711,6 @@ void SearchScreen::onClearFilters()
 
     m_ebookCheck->setChecked(false);
     m_audiobookCheck->setChecked(false);
-
-    m_searchBar->blockSignals(false);
-    m_authorFilter->blockSignals(false);
-    m_genreList->blockSignals(false);
-    m_langList->blockSignals(false);
-    m_srcList->blockSignals(false);
-    m_ebookCheck->blockSignals(false);
-    m_audiobookCheck->blockSignals(false);
 
     m_searchTimer->stop();
     m_authorTimer->stop();
@@ -729,19 +730,7 @@ void SearchScreen::onSortChanged(int index)
         ? QStringLiteral("author")
         : QStringLiteral("title");
 
-    // Re-run if a search is already active
-    const SearchParams params = collectParams();
-    const bool hasQuery = !params.keyword.isEmpty()
-                        || !params.author.isEmpty()
-                        || !params.genres.isEmpty()
-                        || params.yearFrom > 0
-                        || params.yearTo > 0
-                        || !params.languages.isEmpty()
-                        || !params.sources.isEmpty()
-                        || params.ebookOnly
-                        || params.audiobookOnly;
-    if (hasQuery)
-        runSearch();
+    runSearch();
 }
 
 void SearchScreen::onShowMoreGenres()
@@ -752,7 +741,9 @@ void SearchScreen::onShowMoreGenres()
 
     // Resize the list to fit the newly visible items
     const int rows = m_genresExpanded ? m_genreList->count() : kGenreCollapsed;
-    m_genreList->setFixedHeight(rows * 24);
+    const int rowH = m_genreList->sizeHintForRow(0);
+    if (rowH > 0)
+        m_genreList->setFixedHeight(rows * rowH);
 
     m_showMoreGenres->setText(
         m_genresExpanded ? QStringLiteral("show less") : QStringLiteral("show more…"));

--- a/src/gui/screens/search_screen.h
+++ b/src/gui/screens/search_screen.h
@@ -56,6 +56,7 @@ private:
     void buildResultsPane(QWidget *pane);
 
     SearchParams collectParams() const;
+    bool isQueryActive() const;
     void populateModel(const QList<SearchResult> &results, bool append);
     void updateCountLabel(int count);
     void setResultsState(int state); // 0=initial, 1=populated, 2=empty

--- a/src/gui/services/library_service.cpp
+++ b/src/gui/services/library_service.cpp
@@ -76,7 +76,7 @@ int LibraryService::addBook(const QString &bookId, int editionId)
 {
     QSqlQuery query(QSqlDatabase::database());
     query.prepare(QStringLiteral(
-        "INSERT INTO library_items (book_id, edition_id, status) VALUES (?, ?, 'saved')"
+        "INSERT OR IGNORE INTO library_items (book_id, edition_id, status) VALUES (?, ?, 'saved')"
     ));
     query.addBindValue(bookId);
     // Store NULL when no specific edition is chosen — the FK allows NULL.
@@ -91,6 +91,9 @@ int LibraryService::addBook(const QString &bookId, int editionId)
     }
 
     const int newId = query.lastInsertId().toInt();
+    if (newId == 0)
+        return 0;
+
     emit libraryChanged();
     return newId;
 }
@@ -105,6 +108,9 @@ bool LibraryService::removeBook(int libraryItemId)
         qWarning() << "LibraryService::removeBook failed:" << query.lastError().text();
         return false;
     }
+
+    if (query.numRowsAffected() == 0)
+        return true;
 
     emit libraryChanged();
     return true;
@@ -121,6 +127,9 @@ bool LibraryService::updateStatus(int libraryItemId, const QString &status)
         qWarning() << "LibraryService::updateStatus failed:" << query.lastError().text();
         return false;
     }
+
+    if (query.numRowsAffected() == 0)
+        return true;
 
     emit libraryChanged();
     return true;

--- a/src/gui/services/library_service.cpp
+++ b/src/gui/services/library_service.cpp
@@ -90,10 +90,10 @@ int LibraryService::addBook(const QString &bookId, int editionId)
         return -1;
     }
 
-    const int newId = query.lastInsertId().toInt();
-    if (newId == 0)
+    if (query.numRowsAffected() <= 0)
         return 0;
 
+    const int newId = query.lastInsertId().toInt();
     emit libraryChanged();
     return newId;
 }

--- a/src/gui/services/search_service.cpp
+++ b/src/gui/services/search_service.cpp
@@ -16,30 +16,42 @@ SearchService::SearchService(QObject *parent)
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+// Escape SQLite LIKE wildcards so user-supplied text is treated as literal.
+// The backslash escape character is declared in every LIKE clause below.
+static QString escapeLike(const QString &raw)
+{
+    QString out = raw;
+    out.replace(QLatin1Char('\\'), QStringLiteral("\\\\"));
+    out.replace(QLatin1Char('%'),  QStringLiteral("\\%"));
+    out.replace(QLatin1Char('_'),  QStringLiteral("\\_"));
+    return out;
+}
+
 // Builds the WHERE clause and binds values into `query` for all active
 // filters. Returns false if binding fails. The IN-list filters (genres,
 // languages, sources) use one `?` placeholder per value so no user input
 // is ever interpolated into SQL text.
 static bool bindParams(QSqlQuery &query,
                        const SearchParams &p,
-                       const QString &sqlTemplate,
                        int offset,
                        int limit,
                        bool isCount)
 {
     // keyword
-    const QString kw = p.keyword.trimmed().isEmpty()
+    const QString kwTrimmed = p.keyword.trimmed();
+    const QString kw = kwTrimmed.isEmpty()
                      ? QStringLiteral("")
-                     : QStringLiteral("%%1%").arg(p.keyword.trimmed());
-    query.addBindValue(p.keyword.trimmed().isEmpty() ? QStringLiteral("") : QStringLiteral("x")); // sentinel for "? = ''"
+                     : QStringLiteral("%") + escapeLike(kwTrimmed) + QStringLiteral("%");
+    query.addBindValue(kwTrimmed.isEmpty() ? QStringLiteral("") : QStringLiteral("x")); // sentinel for "? = ''"
     query.addBindValue(kw);
     query.addBindValue(kw);
 
     // author filter
-    const QString af = p.author.trimmed().isEmpty()
+    const QString afTrimmed = p.author.trimmed();
+    const QString af = afTrimmed.isEmpty()
                      ? QStringLiteral("")
-                     : QStringLiteral("%%1%").arg(p.author.trimmed());
-    query.addBindValue(p.author.trimmed().isEmpty() ? QStringLiteral("") : QStringLiteral("x"));
+                     : QStringLiteral("%") + escapeLike(afTrimmed) + QStringLiteral("%");
+    query.addBindValue(afTrimmed.isEmpty() ? QStringLiteral("") : QStringLiteral("x"));
     query.addBindValue(af);
 
     // genre IN values
@@ -73,7 +85,6 @@ static bool bindParams(QSqlQuery &query,
         query.addBindValue(offset);
     }
 
-    Q_UNUSED(sqlTemplate)
     return true;
 }
 
@@ -126,6 +137,12 @@ static QString buildSql(const SearchParams &p, bool isCount)
         ? QStringLiteral("JOIN library_items li ON b.book_id = li.book_id")
         : QStringLiteral("LEFT JOIN library_items li ON b.book_id = li.book_id");
 
+    // Whitelist the sort column to prevent SQL injection; only "author" is an
+    // alternative — everything else falls back to the default "title".
+    const QString orderCol = (p.sortColumn == QLatin1String("author"))
+                             ? QStringLiteral("b.author")
+                             : QStringLiteral("b.title");
+
     if (isCount) {
         return QStringLiteral(R"(
             SELECT COUNT(DISTINCT b.book_id)
@@ -135,8 +152,8 @@ static QString buildSql(const SearchParams &p, bool isCount)
             LEFT JOIN formats f ON e.id = f.edition_id
             LEFT JOIN sources s ON f.id = s.format_id
             %2
-            WHERE (? = '' OR b.title LIKE ? OR b.author LIKE ?)
-              AND (? = '' OR b.author LIKE ?)
+            WHERE (? = '' OR b.title LIKE ? ESCAPE '\' OR b.author LIKE ? ESCAPE '\')
+              AND (? = '' OR b.author LIKE ? ESCAPE '\')
               %3
               AND (? = 0 OR b.publish_year >= ?)
               AND (? = 0 OR b.publish_year <= ?)
@@ -148,7 +165,7 @@ static QString buildSql(const SearchParams &p, bool isCount)
     }
 
     return QStringLiteral(R"(
-        SELECT DISTINCT b.book_id, b.title, b.author, b.publish_year,
+        SELECT b.book_id, b.title, b.author, b.publish_year,
                GROUP_CONCAT(DISTINCT e.language)    AS languages,
                GROUP_CONCAT(DISTINCT s.source_name) AS sources,
                GROUP_CONCAT(DISTINCT f.format_type) AS formats,
@@ -159,8 +176,8 @@ static QString buildSql(const SearchParams &p, bool isCount)
         LEFT JOIN formats f ON e.id = f.edition_id
         LEFT JOIN sources s ON f.id = s.format_id
         %2
-        WHERE (? = '' OR b.title LIKE ? OR b.author LIKE ?)
-          AND (? = '' OR b.author LIKE ?)
+        WHERE (? = '' OR b.title LIKE ? ESCAPE '\' OR b.author LIKE ? ESCAPE '\')
+          AND (? = '' OR b.author LIKE ? ESCAPE '\')
           %3
           AND (? = 0 OR b.publish_year >= ?)
           AND (? = 0 OR b.publish_year <= ?)
@@ -169,9 +186,9 @@ static QString buildSql(const SearchParams &p, bool isCount)
           AND (? = 0 OR f.format_type IS NOT NULL)
           AND (? = 0 OR li.status = 'audiobook_ready')
         GROUP BY b.book_id
-        ORDER BY b.title
+        ORDER BY %6
         LIMIT ? OFFSET ?
-    )").arg(genreJoin, liJoin, genreFilter, langFilter, srcFilter);
+    )").arg(genreJoin, liJoin, genreFilter, langFilter, srcFilter, orderCol);
 }
 
 // ---------------------------------------------------------------------------
@@ -183,7 +200,7 @@ QList<SearchResult> SearchService::search(const SearchParams &params,
     const QString sql = buildSql(params, false);
     QSqlQuery query(QSqlDatabase::database());
     query.prepare(sql);
-    bindParams(query, params, sql, offset, limit, false);
+    bindParams(query, params, offset, limit, false);
 
     if (!query.exec()) {
         qWarning() << "SearchService::search failed:" << query.lastError().text();
@@ -221,7 +238,7 @@ int SearchService::count(const SearchParams &params) const
     const QString sql = buildSql(params, true);
     QSqlQuery query(QSqlDatabase::database());
     query.prepare(sql);
-    bindParams(query, params, sql, 0, 0, true);
+    bindParams(query, params, 0, 0, true);
 
     if (!query.exec() || !query.next()) {
         qWarning() << "SearchService::count failed:" << query.lastError().text();

--- a/src/gui/services/search_service.h
+++ b/src/gui/services/search_service.h
@@ -17,6 +17,7 @@ struct SearchParams {
     QStringList sources;
     bool        ebookOnly{false};
     bool        audiobookOnly{false};
+    QString     sortColumn{QStringLiteral("title")}; // "title" or "author"
 };
 
 struct SearchResult {

--- a/src/gui/widgets/book_card_delegate.cpp
+++ b/src/gui/widgets/book_card_delegate.cpp
@@ -173,7 +173,7 @@ void BookCardDelegate::paintListRow(QPainter *painter,
 
     // Status text after badges
     auto [statusText, statusColor] = statusDisplay(status);
-    painter->setPen(QColor(statusColor.toStdString().c_str()));
+    painter->setPen(QColor(statusColor));
     painter->setFont(badgeFont);
     const QRect statusRect(badgeX + SpacingXS, badgeY, textRight - badgeX - SpacingXS, badgeH);
     painter->drawText(statusRect, Qt::AlignLeft | Qt::AlignVCenter, statusText);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include <QApplication>
 #include <QIcon>
 #include <QDir>
+#include <QMessageBox>
 #include "shared/database.h"
 #include "collector/collector_worker.h"
 #include "gui/main_window.h"
@@ -9,13 +10,18 @@ int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
 
-    if (bookhub::db::initializeDatabase(bookhub::db::databaseFilePath())) {
-        if (!bookhub::db::verifySchemaVersion()) {
-            return 1;
-        }
-        bookhub::db::createSchema();
-        bookhub::db::insertSampleData();
+    if (!bookhub::db::initializeDatabase(bookhub::db::databaseFilePath())) {
+        QMessageBox::critical(nullptr,
+            QStringLiteral("Database error"),
+            QStringLiteral("Failed to open the database. The application cannot start."));
+        return 1;
     }
+
+    if (!bookhub::db::verifySchemaVersion()) {
+        return 1;
+    }
+    bookhub::db::createSchema();
+    bookhub::db::insertSampleData();
 
     // Start background collector thread
     bookhub::collector::CollectorWorker collector;

--- a/src/shared/database.cpp
+++ b/src/shared/database.cpp
@@ -34,6 +34,12 @@ bool initializeDatabase(const QString &filePath, const QString &connectionName)
         qWarning() << "Failed to enable foreign keys:" << query.lastError().text();
     }
 
+    // WAL mode allows the GUI thread to read while the collector holds a write
+    // lock, preventing UI stalls during background discovery runs.
+    if (!query.exec("PRAGMA journal_mode = WAL;")) {
+        qWarning() << "Failed to enable WAL journal mode:" << query.lastError().text();
+    }
+
     qDebug() << "Opened SQLite database at" << filePath << "with connection:" << connectionName;
     return true;
 }
@@ -81,6 +87,7 @@ bool createSchema(const QString &connectionName)
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             edition_id INTEGER NOT NULL,
             format_type TEXT NOT NULL,
+            UNIQUE(edition_id, format_type),
             FOREIGN KEY (edition_id) REFERENCES editions(id) ON DELETE CASCADE
         ))",
         R"(CREATE TABLE IF NOT EXISTS sources (
@@ -88,11 +95,12 @@ bool createSchema(const QString &connectionName)
             format_id INTEGER NOT NULL,
             source_name TEXT NOT NULL,
             download_link TEXT NOT NULL,
+            UNIQUE(format_id, source_name),
             FOREIGN KEY (format_id) REFERENCES formats(id) ON DELETE CASCADE
         ))",
         R"(CREATE TABLE IF NOT EXISTS library_items (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            book_id TEXT NOT NULL,
+            book_id TEXT NOT NULL UNIQUE,
             edition_id INTEGER,
             added_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             status TEXT,
@@ -108,7 +116,7 @@ bool createSchema(const QString &connectionName)
         }
     }
 
-    if (!query.exec("PRAGMA user_version = 1")) {
+    if (!query.exec(QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion))) {
         qWarning() << "Failed to set user_version:" << query.lastError().text();
         return false;
     }
@@ -137,6 +145,65 @@ bool verifySchemaVersion(const QString &connectionName)
         tableCheck.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='books'");
         if (!tableCheck.next())
             return true; // no tables yet — fresh DB
+    }
+
+    // Migration: version 1 → 2
+    // Adds UNIQUE(edition_id, format_type) on formats,
+    // UNIQUE(format_id, source_name) on sources, and UNIQUE(book_id) on
+    // library_items. SQLite does not support ADD CONSTRAINT, so we recreate
+    // each table using the standard rename-insert-drop pattern.
+    if (version == 1) {
+        qDebug() << "Migrating database schema from version 1 to 2...";
+        QStringList migration = {
+            "BEGIN",
+            R"(CREATE TABLE formats_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                edition_id INTEGER NOT NULL,
+                format_type TEXT NOT NULL,
+                UNIQUE(edition_id, format_type),
+                FOREIGN KEY (edition_id) REFERENCES editions(id) ON DELETE CASCADE
+            ))",
+            "INSERT OR IGNORE INTO formats_new SELECT * FROM formats",
+            "DROP TABLE formats",
+            "ALTER TABLE formats_new RENAME TO formats",
+            R"(CREATE TABLE sources_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                format_id INTEGER NOT NULL,
+                source_name TEXT NOT NULL,
+                download_link TEXT NOT NULL,
+                UNIQUE(format_id, source_name),
+                FOREIGN KEY (format_id) REFERENCES formats(id) ON DELETE CASCADE
+            ))",
+            "INSERT OR IGNORE INTO sources_new SELECT * FROM sources",
+            "DROP TABLE sources",
+            "ALTER TABLE sources_new RENAME TO sources",
+            R"(CREATE TABLE library_items_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                book_id TEXT NOT NULL UNIQUE,
+                edition_id INTEGER,
+                added_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                status TEXT,
+                FOREIGN KEY (book_id) REFERENCES books(book_id) ON DELETE CASCADE ON UPDATE CASCADE,
+                FOREIGN KEY (edition_id) REFERENCES editions(id)
+            ))",
+            "INSERT OR IGNORE INTO library_items_new SELECT * FROM library_items",
+            "DROP TABLE library_items",
+            "ALTER TABLE library_items_new RENAME TO library_items",
+            QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion),
+            "COMMIT"
+        };
+
+        QSqlQuery mq(db);
+        for (const QString &sql : migration) {
+            if (!mq.exec(sql)) {
+                qCritical() << "Migration v1→v2 failed at:" << sql
+                            << "\nError:" << mq.lastError().text();
+                mq.exec("ROLLBACK");
+                return false;
+            }
+        }
+        qDebug() << "Migration to schema version 2 complete.";
+        return true;
     }
 
     fprintf(stderr,

--- a/src/shared/database.h
+++ b/src/shared/database.h
@@ -6,7 +6,7 @@
 
 namespace bookhub::db {
 
-inline constexpr int kSchemaVersion = 1;
+inline constexpr int kSchemaVersion = 2;
 
 /// Returns the absolute path to the database file, located next to the executable.
 QString databaseFilePath();

--- a/tests/gui/test_explore_screen.cpp
+++ b/tests/gui/test_explore_screen.cpp
@@ -1,0 +1,92 @@
+#include <QWidget>
+#include <QStackedWidget>
+#include <QLabel>
+#include <QPushButton>
+#include <QGridLayout>
+
+#define private public
+#include "gui/screens/explore_screen.h"
+#undef private
+
+#include "support/test_database_utils.h"
+
+#include <QtTest>
+#include <memory>
+
+using namespace bookhub::gui;
+
+class ExploreScreenTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+    void categoryClick_updatesBreadcrumbAndSupportsBack();
+    void loadMoreAndBookClick_emitExpectedSignals();
+
+private:
+    std::unique_ptr<bookhub::tests::TestDatabase> m_db;
+};
+
+void ExploreScreenTest::init()
+{
+    m_db = std::make_unique<bookhub::tests::TestDatabase>();
+    QVERIFY(m_db->open());
+    QVERIFY(m_db->createSchema());
+
+    QVERIFY(bookhub::tests::execSql(m_db->database(), QStringLiteral(
+        "INSERT INTO genres (id, genre_name) VALUES (1, 'Epic')")));
+
+    for (int i = 0; i < 45; ++i) {
+        QVERIFY(bookhub::tests::execSql(m_db->database(), QStringLiteral(
+            "INSERT INTO books (book_id, title, author) VALUES ('epic:%1', 'Epic Book %1', 'Author %1')").arg(i)));
+        QVERIFY(bookhub::tests::execSql(m_db->database(), QStringLiteral(
+            "INSERT INTO book_genres (book_id, genre_id) VALUES ('epic:%1', 1)").arg(i)));
+    }
+}
+
+void ExploreScreenTest::cleanup()
+{
+    m_db.reset();
+}
+
+void ExploreScreenTest::categoryClick_updatesBreadcrumbAndSupportsBack()
+{
+    ExploreScreen screen;
+    screen.onCategoryClicked(QStringLiteral("Epic"));
+
+    QCOMPARE(screen.m_exploreStack->currentIndex(), 1);
+    QCOMPARE(screen.m_breadcrumb->text(), QStringLiteral("Epic"));
+
+    auto buttons = screen.findChildren<QPushButton *>();
+    auto it = std::find_if(buttons.begin(), buttons.end(), [](QPushButton *button) {
+        return button->text().contains(QStringLiteral("Back"));
+    });
+    QVERIFY(it != buttons.end());
+    (*it)->click();
+    QCOMPARE(screen.m_exploreStack->currentIndex(), 0);
+}
+
+void ExploreScreenTest::loadMoreAndBookClick_emitExpectedSignals()
+{
+    ExploreScreen screen;
+    QSignalSpy spy(&screen, &ExploreScreen::bookDetailsRequested);
+
+    screen.onCategoryClicked(QStringLiteral("Epic"));
+    QVERIFY(!screen.m_loadMoreBtn->isHidden());
+    const int initialItemCount = screen.m_genreGridLayout->count();
+    QVERIFY(initialItemCount >= 40);
+
+    screen.onLoadMore();
+    QVERIFY(screen.m_genreGridLayout->count() > initialItemCount);
+
+    QWidget *firstCard = screen.m_genreGridLayout->itemAt(0)->widget();
+    QVERIFY(firstCard);
+    QTest::mouseClick(firstCard, Qt::LeftButton);
+    QCOMPARE(spy.count(), 1);
+}
+
+QTEST_MAIN(ExploreScreenTest)
+
+#include "test_explore_screen.moc"

--- a/tests/gui/test_library_screen.cpp
+++ b/tests/gui/test_library_screen.cpp
@@ -1,0 +1,121 @@
+#include <QWidget>
+#include <QListView>
+#include <QComboBox>
+#include <QButtonGroup>
+#include <QStackedWidget>
+#include <QStandardItemModel>
+
+#define private public
+#include "gui/screens/library_screen.h"
+#undef private
+
+#include "gui/widgets/book_card_delegate.h"
+#include "gui/widgets/empty_state_widget.h"
+#include "support/test_database_utils.h"
+
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSettings>
+#include <QSignalSpy>
+#include <QtTest>
+#include <memory>
+
+using namespace bookhub::gui;
+
+class LibraryScreenTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+    void emptyState_emitsExploreRequested();
+    void populatedState_supportsSortingAndDetails();
+    void viewMode_persistsAndRemoveActionDeletesRow();
+
+private:
+    std::unique_ptr<bookhub::tests::TestDatabase> m_db;
+};
+
+void LibraryScreenTest::init()
+{
+    bookhub::tests::isolateSettings(QStringLiteral("bookhub-test-library-screen"));
+    QSettings settings(QStringLiteral("BookHub"), QStringLiteral("BookHub"));
+    settings.clear();
+
+    m_db = std::make_unique<bookhub::tests::TestDatabase>();
+    QVERIFY(m_db->open());
+    QVERIFY(m_db->createSchema());
+}
+
+void LibraryScreenTest::cleanup()
+{
+    m_db.reset();
+}
+
+void LibraryScreenTest::emptyState_emitsExploreRequested()
+{
+    LibraryScreen screen;
+    QSignalSpy spy(&screen, &LibraryScreen::exploreRequested);
+
+    QCOMPARE(screen.m_stack->currentIndex(), 1);
+    QVERIFY(screen.m_emptyState);
+    emit screen.m_emptyState->ctaClicked();
+    QCOMPARE(spy.count(), 1);
+}
+
+void LibraryScreenTest::populatedState_supportsSortingAndDetails()
+{
+    QVERIFY(m_db->insertSampleData());
+
+    LibraryScreen screen;
+    QSignalSpy detailsSpy(&screen, &LibraryScreen::bookDetailsRequested);
+
+    QCOMPARE(screen.m_stack->currentIndex(), 0);
+    QVERIFY(screen.m_model->rowCount() >= 2);
+
+    screen.m_sortCombo->setCurrentIndex(1);
+    QCOMPARE(screen.m_model->item(0)->data(LibraryRole::Title).toString(),
+             QStringLiteral("Pride and Prejudice"));
+
+    const QModelIndex firstIndex = screen.m_model->index(0, 0);
+    emit screen.m_listView->doubleClicked(firstIndex);
+    QCOMPARE(detailsSpy.count(), 1);
+}
+
+void LibraryScreenTest::viewMode_persistsAndRemoveActionDeletesRow()
+{
+    QVERIFY(m_db->insertSampleData());
+
+    LibraryScreen screen;
+    screen.show();
+    auto *gridButton = qobject_cast<QPushButton *>(screen.m_viewGroup->button(1));
+    QVERIFY(gridButton);
+    gridButton->click();
+
+    QSettings settings(QStringLiteral("BookHub"), QStringLiteral("BookHub"));
+    QCOMPARE(settings.value(QStringLiteral("Library/viewMode")).toInt(), 1);
+    QCOMPARE(screen.m_listView->viewMode(), QListView::IconMode);
+
+    const int initialRows = screen.m_model->rowCount();
+    const int libraryItemId = screen.m_model->item(0)->data(LibraryRole::LibraryItemId).toInt();
+
+    QTimer acceptTimer;
+    connect(&acceptTimer, &QTimer::timeout, &screen, [] {
+        if (auto *box = qobject_cast<QMessageBox *>(QApplication::activeModalWidget())) {
+            if (auto *button = box->button(QMessageBox::Yes))
+                button->click();
+        }
+    });
+    acceptTimer.start(10);
+
+    screen.onRemoveRequested(libraryItemId, screen.m_model->item(0)->data(LibraryRole::BookId).toString());
+    acceptTimer.stop();
+    QCOMPARE(m_db->scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM library_items WHERE id = %1").arg(libraryItemId)), 0);
+    QCOMPARE(screen.m_model->rowCount(), initialRows - 1);
+}
+
+QTEST_MAIN(LibraryScreenTest)
+
+#include "test_library_screen.moc"

--- a/tests/gui/test_main_window.cpp
+++ b/tests/gui/test_main_window.cpp
@@ -1,0 +1,74 @@
+#include <QMainWindow>
+#include <QStackedWidget>
+#include <QButtonGroup>
+#include <QLabel>
+
+#define private public
+#include "gui/main_window.h"
+#undef private
+
+#include "gui/style_tokens.h"
+#include "support/test_database_utils.h"
+
+#include <QPushButton>
+#include <QtTest>
+
+using namespace bookhub::gui;
+
+class MainWindowTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+    void window_initializesWithExpectedDefaults();
+    void navigation_buttonsSwitchPages();
+    void collectorSlots_updateStatusUi();
+};
+
+void MainWindowTest::initTestCase()
+{
+    bookhub::tests::isolateSettings(QStringLiteral("bookhub-test-main-window"));
+}
+
+void MainWindowTest::window_initializesWithExpectedDefaults()
+{
+    MainWindow window;
+    QCOMPARE(window.minimumWidth(), WindowMinWidth);
+    QCOMPARE(window.minimumHeight(), WindowMinHeight);
+    QCOMPARE(window.m_stack->currentIndex(), 0);
+}
+
+void MainWindowTest::navigation_buttonsSwitchPages()
+{
+    MainWindow window;
+    auto *searchButton = qobject_cast<QPushButton *>(window.m_navGroup->button(1));
+    auto *exploreButton = qobject_cast<QPushButton *>(window.m_navGroup->button(2));
+    QVERIFY(searchButton);
+    QVERIFY(exploreButton);
+
+    searchButton->click();
+    QCOMPARE(window.m_stack->currentIndex(), 1);
+    QVERIFY(searchButton->isChecked());
+
+    exploreButton->click();
+    QCOMPARE(window.m_stack->currentIndex(), 2);
+    QVERIFY(exploreButton->isChecked());
+    QVERIFY(!searchButton->isChecked());
+}
+
+void MainWindowTest::collectorSlots_updateStatusUi()
+{
+    MainWindow window;
+    window.onCollectorStatusChanged(QStringLiteral("Collector: running"));
+    QCOMPARE(window.m_statusLabel->text(), QStringLiteral("Collector: running"));
+    QVERIFY(window.m_statusDot->styleSheet().contains(QStringLiteral("#d97706"), Qt::CaseInsensitive));
+
+    window.onCollectorErrorOccurred(QStringLiteral("network failed"));
+    QCOMPARE(window.m_statusLabel->text(), QStringLiteral("Collector error: network failed"));
+    QVERIFY(window.m_statusDot->styleSheet().contains(QStringLiteral("#dc2626"), Qt::CaseInsensitive));
+}
+
+QTEST_MAIN(MainWindowTest)
+
+#include "test_main_window.moc"

--- a/tests/gui/test_search_screen.cpp
+++ b/tests/gui/test_search_screen.cpp
@@ -1,0 +1,127 @@
+#include <QWidget>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QSpinBox>
+#include <QCheckBox>
+#include <QPushButton>
+#include <QLabel>
+#include <QListView>
+#include <QStackedWidget>
+#include <QStandardItemModel>
+#include <QTimer>
+#include <QSplitter>
+
+#define private public
+#include "gui/screens/search_screen.h"
+#undef private
+
+#include "gui/widgets/search_result_delegate.h"
+#include "support/test_database_utils.h"
+
+#include <QtTest>
+#include <memory>
+
+using namespace bookhub::gui;
+
+class SearchScreenTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+    void debounceAndEnterTriggerSearch();
+    void clearFiltersAndAddToLibrary_updateUiState();
+    void loadMoreAndYearClamp_work();
+
+private:
+    std::unique_ptr<bookhub::tests::TestDatabase> m_db;
+};
+
+void SearchScreenTest::init()
+{
+    m_db = std::make_unique<bookhub::tests::TestDatabase>();
+    QVERIFY(m_db->open());
+    QVERIFY(m_db->createSchema());
+    QVERIFY(m_db->insertSampleData());
+
+    for (int i = 0; i < 60; ++i) {
+        const int id = 1000 + i;
+        QVERIFY(bookhub::tests::execSql(m_db->database(), QStringLiteral(
+            "INSERT INTO books (book_id, title, author, publish_year) "
+            "VALUES ('bulk:%1', 'Bulk Book %1', 'Bulk Author', 1900)").arg(id)));
+        QVERIFY(bookhub::tests::execSql(m_db->database(), QStringLiteral(
+            "INSERT INTO editions (book_id, language) VALUES ('bulk:%1', 'English')").arg(id)));
+        const int editionId = m_db->scalarInt(QStringLiteral(
+            "SELECT id FROM editions WHERE book_id = 'bulk:%1'").arg(id));
+        QVERIFY(bookhub::tests::execSql(m_db->database(), QStringLiteral(
+            "INSERT INTO formats (edition_id, format_type) VALUES (%1, 'epub')").arg(editionId)));
+        const int formatId = m_db->scalarInt(QStringLiteral(
+            "SELECT id FROM formats WHERE edition_id = %1").arg(editionId));
+        QVERIFY(bookhub::tests::execSql(m_db->database(), QStringLiteral(
+            "INSERT INTO sources (format_id, source_name, download_link) "
+            "VALUES (%1, 'Gutenberg', 'https://example.test/%2.epub')").arg(formatId).arg(id)));
+    }
+}
+
+void SearchScreenTest::cleanup()
+{
+    m_db.reset();
+}
+
+void SearchScreenTest::debounceAndEnterTriggerSearch()
+{
+    SearchScreen screen;
+
+    screen.m_searchBar->setText(QStringLiteral("Pride"));
+    QCOMPARE(screen.m_resultsStack->currentIndex(), 0);
+
+    QTest::qWait(550);
+    QCOMPARE(screen.m_resultsStack->currentIndex(), 1);
+    QVERIFY(screen.m_model->rowCount() >= 1);
+
+    screen.m_searchBar->clear();
+    screen.m_searchBar->setText(QStringLiteral("Huckleberry"));
+    QTest::keyClick(screen.m_searchBar, Qt::Key_Return);
+    QCOMPARE(screen.m_resultsStack->currentIndex(), 1);
+    QVERIFY(screen.m_model->rowCount() >= 1);
+}
+
+void SearchScreenTest::clearFiltersAndAddToLibrary_updateUiState()
+{
+    SearchScreen screen;
+    screen.m_searchBar->setText(QStringLiteral("Pride"));
+    QTest::qWait(550);
+
+    QVERIFY(screen.m_model->rowCount() >= 1);
+    const QString firstBookId = screen.m_model->item(0)->data(SearchRole::BookId).toString();
+    screen.onAddToLibrary(firstBookId);
+    QCOMPARE(screen.m_model->item(0)->data(SearchRole::InLibrary).toBool(), true);
+
+    screen.onClearFilters();
+    QCOMPARE(screen.m_resultsStack->currentIndex(), 0);
+    QCOMPARE(screen.m_model->rowCount(), 0);
+    QVERIFY(screen.m_searchBar->text().isEmpty());
+}
+
+void SearchScreenTest::loadMoreAndYearClamp_work()
+{
+    SearchScreen screen;
+    screen.m_searchBar->setText(QStringLiteral("Bulk"));
+    QTest::qWait(550);
+
+    const int initialRows = screen.m_model->rowCount();
+    QVERIFY(initialRows == 50);
+    QVERIFY(!screen.m_loadMoreBtn->isHidden());
+
+    screen.onLoadMore();
+    QVERIFY(screen.m_model->rowCount() > initialRows);
+
+    screen.m_yearTo->setValue(1800);
+    screen.m_yearFrom->setValue(1900);
+    QCOMPARE(screen.m_yearTo->value(), 1900);
+}
+
+QTEST_MAIN(SearchScreenTest)
+
+#include "test_search_screen.moc"

--- a/tests/integration/test_book_discovery_service.cpp
+++ b/tests/integration/test_book_discovery_service.cpp
@@ -2,10 +2,7 @@
 #include <QString>
 #include <QList>
 
-#define private public
 #include "collector/book_discovery_service.h"
-#undef private
-
 #include "collector/source_adapter.h"
 #include "support/test_database_utils.h"
 

--- a/tests/integration/test_book_discovery_service.cpp
+++ b/tests/integration/test_book_discovery_service.cpp
@@ -1,0 +1,95 @@
+#include <QObject>
+#include <QString>
+#include <QList>
+
+#define private public
+#include "collector/book_discovery_service.h"
+#undef private
+
+#include "collector/source_adapter.h"
+#include "support/test_database_utils.h"
+
+#include <QtTest>
+
+using namespace bookhub::collector;
+
+class BookDiscoveryServiceTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void insertBookIntoDatabase_insertsAndDoesNotDuplicate();
+    void strongerIdentifier_promotesPrimaryKeyAndPreservesDependents();
+};
+
+static DiscoveredBook makeFallbackBook()
+{
+    DiscoveredBook book;
+    book.sourceId = QStringLiteral("1342");
+    book.resolvedId = QStringLiteral("gutenberg:1342");
+    book.title = QStringLiteral("Pride and Prejudice");
+    book.authors = {QStringLiteral("Jane Austen")};
+    book.languages = {QStringLiteral("English")};
+    book.identifiers = {BookIdentifier{QStringLiteral("gutenberg"), QStringLiteral("1342")}};
+    book.formats.insert(QStringLiteral("epub_1"), QStringLiteral("https://example.test/1342.epub"));
+    return book;
+}
+
+void BookDiscoveryServiceTest::insertBookIntoDatabase_insertsAndDoesNotDuplicate()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open(QStringLiteral("discovery_insert")));
+    QVERIFY(testDb.createSchema());
+
+    BookDiscoveryService service(testDb.connection());
+    const DiscoveredBook book = makeFallbackBook();
+
+    service.insertBookIntoDatabase(book, QStringLiteral("Gutenberg"));
+    service.insertBookIntoDatabase(book, QStringLiteral("Gutenberg"));
+
+    QCOMPARE(testDb.scalarInt(QStringLiteral("SELECT COUNT(*) FROM books")), 1);
+    QCOMPARE(testDb.scalarInt(QStringLiteral("SELECT COUNT(*) FROM book_identifiers")), 1);
+    QCOMPARE(testDb.scalarInt(QStringLiteral("SELECT COUNT(*) FROM editions")), 1);
+    QCOMPARE(testDb.scalarInt(QStringLiteral("SELECT COUNT(*) FROM formats")), 1);
+    QCOMPARE(testDb.scalarInt(QStringLiteral("SELECT COUNT(*) FROM sources")), 1);
+}
+
+void BookDiscoveryServiceTest::strongerIdentifier_promotesPrimaryKeyAndPreservesDependents()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open(QStringLiteral("discovery_promote")));
+    QVERIFY(testDb.createSchema());
+
+    BookDiscoveryService service(testDb.connection());
+    service.insertBookIntoDatabase(makeFallbackBook(), QStringLiteral("Gutenberg"));
+
+    const int editionId = testDb.scalarInt(QStringLiteral(
+        "SELECT id FROM editions WHERE book_id = 'gutenberg:1342'"));
+    QVERIFY(editionId > 0);
+    QVERIFY(bookhub::tests::execSql(testDb.database(), QStringLiteral(
+        "INSERT INTO library_items (book_id, edition_id, status) "
+        "VALUES ('gutenberg:1342', %1, 'saved')").arg(editionId)));
+
+    DiscoveredBook stronger = makeFallbackBook();
+    stronger.resolvedId = QStringLiteral("lccn:n78095332");
+    stronger.identifiers = {
+        BookIdentifier{QStringLiteral("lccn"), QStringLiteral("n78095332")},
+        BookIdentifier{QStringLiteral("gutenberg"), QStringLiteral("1342")}
+    };
+
+    service.insertBookIntoDatabase(stronger, QStringLiteral("Gutenberg"));
+
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM books WHERE book_id = 'lccn:n78095332'")), 1);
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM books WHERE book_id = 'gutenberg:1342'")), 0);
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM library_items WHERE book_id = 'lccn:n78095332'")), 1);
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM book_identifiers WHERE book_id = 'lccn:n78095332' AND type = 'gutenberg' AND value = '1342'")),
+        1);
+}
+
+QTEST_GUILESS_MAIN(BookDiscoveryServiceTest)
+
+#include "test_book_discovery_service.moc"

--- a/tests/integration/test_explore_service.cpp
+++ b/tests/integration/test_explore_service.cpp
@@ -48,7 +48,11 @@ void ExploreServiceTest::fetchTrendingAndGenreBooks_returnExpectedWindows()
     const QList<ExploreBook> arrivals = service.fetchNewArrivals();
     QVERIFY(!trending.isEmpty());
     QVERIFY(!arrivals.isEmpty());
+    // fetchTrending() selects ORDER BY rowid DESC LIMIT 20. Books 1..25 were
+    // inserted in ascending order, so book:25 has the highest rowid and is first.
     QCOMPARE(trending.first().bookId, QStringLiteral("book:25"));
+    // fetchNewArrivals() applies OFFSET 20 to the same rowid-DESC order, skipping
+    // books 25..6. book:5 is the first of the remaining window (5, 4, 3, 2, 1).
     QCOMPARE(arrivals.first().bookId, QStringLiteral("book:5"));
 
     const QList<ExploreBook> genreBooks = service.fetchBooksForGenre(QStringLiteral("Genre10"));

--- a/tests/integration/test_explore_service.cpp
+++ b/tests/integration/test_explore_service.cpp
@@ -1,0 +1,61 @@
+#include "gui/services/explore_service.h"
+#include "support/test_database_utils.h"
+
+#include <QtTest>
+
+using namespace bookhub::gui;
+
+class ExploreServiceTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void fetchCategories_returnsCounts();
+    void fetchTrendingAndGenreBooks_returnExpectedWindows();
+};
+
+void ExploreServiceTest::fetchCategories_returnsCounts()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open());
+    QVERIFY(testDb.createSchema());
+    QVERIFY(testDb.insertSampleData());
+
+    ExploreService service;
+    const QList<ExploreCategory> categories = service.fetchCategories();
+    QVERIFY(!categories.isEmpty());
+    QCOMPARE(categories.first().genreName, QStringLiteral("Classic"));
+    QCOMPARE(categories.first().bookCount, 3);
+}
+
+void ExploreServiceTest::fetchTrendingAndGenreBooks_returnExpectedWindows()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open());
+    QVERIFY(testDb.createSchema());
+
+    for (int i = 1; i <= 25; ++i) {
+        QVERIFY(bookhub::tests::execSql(testDb.database(), QStringLiteral(
+            "INSERT INTO books (book_id, title, author) VALUES ('book:%1', 'Book %1', 'Author %1')").arg(i)));
+        QVERIFY(bookhub::tests::execSql(testDb.database(), QStringLiteral(
+            "INSERT OR IGNORE INTO genres (id, genre_name) VALUES (%1, 'Genre%1')").arg(i)));
+        QVERIFY(bookhub::tests::execSql(testDb.database(), QStringLiteral(
+            "INSERT INTO book_genres (book_id, genre_id) VALUES ('book:%1', %2)").arg(i).arg(i)));
+    }
+
+    ExploreService service;
+    const QList<ExploreBook> trending = service.fetchTrending();
+    const QList<ExploreBook> arrivals = service.fetchNewArrivals();
+    QVERIFY(!trending.isEmpty());
+    QVERIFY(!arrivals.isEmpty());
+    QCOMPARE(trending.first().bookId, QStringLiteral("book:25"));
+    QCOMPARE(arrivals.first().bookId, QStringLiteral("book:5"));
+
+    const QList<ExploreBook> genreBooks = service.fetchBooksForGenre(QStringLiteral("Genre10"));
+    QCOMPARE(genreBooks.size(), 1);
+    QCOMPARE(genreBooks.first().bookId, QStringLiteral("book:10"));
+}
+
+QTEST_GUILESS_MAIN(ExploreServiceTest)
+
+#include "test_explore_service.moc"

--- a/tests/integration/test_library_service.cpp
+++ b/tests/integration/test_library_service.cpp
@@ -42,7 +42,10 @@ void LibraryServiceTest::writeOperations_emitSignalsAndMutateRows()
     LibraryService service;
     QSignalSpy spy(&service, &LibraryService::libraryChanged);
 
-    const int addedId = service.addBook(QStringLiteral("gutenberg:1184"), 4);
+    const int editionId = testDb.scalarInt(QStringLiteral(
+        "SELECT id FROM editions WHERE book_id = 'gutenberg:1184' AND language = 'English'"));
+    QVERIFY(editionId > 0);
+    const int addedId = service.addBook(QStringLiteral("gutenberg:1184"), editionId);
     QVERIFY(addedId > 0);
     QCOMPARE(spy.count(), 1);
 

--- a/tests/integration/test_library_service.cpp
+++ b/tests/integration/test_library_service.cpp
@@ -1,0 +1,64 @@
+#include "gui/services/library_service.h"
+#include "support/test_database_utils.h"
+
+#include <QSignalSpy>
+#include <QtTest>
+
+using namespace bookhub::gui;
+
+class LibraryServiceTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void fetchItems_returnsRowsInRequestedSortOrder();
+    void writeOperations_emitSignalsAndMutateRows();
+};
+
+void LibraryServiceTest::fetchItems_returnsRowsInRequestedSortOrder()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open());
+    QVERIFY(testDb.createSchema());
+    QVERIFY(testDb.insertSampleData());
+
+    LibraryService service;
+    const QList<LibraryItem> byTitle = service.fetchItems(QStringLiteral("title"));
+    QVERIFY(byTitle.size() >= 2);
+    QCOMPARE(byTitle.first().title, QStringLiteral("Pride and Prejudice"));
+
+    const QList<LibraryItem> byStatus = service.fetchItems(QStringLiteral("status"));
+    QVERIFY(byStatus.size() >= 2);
+    QCOMPARE(byStatus.first().status, QStringLiteral("downloaded"));
+}
+
+void LibraryServiceTest::writeOperations_emitSignalsAndMutateRows()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open());
+    QVERIFY(testDb.createSchema());
+    QVERIFY(testDb.insertSampleData());
+
+    LibraryService service;
+    QSignalSpy spy(&service, &LibraryService::libraryChanged);
+
+    const int addedId = service.addBook(QStringLiteral("gutenberg:1184"), 4);
+    QVERIFY(addedId > 0);
+    QCOMPARE(spy.count(), 1);
+
+    QVERIFY(service.updateStatus(addedId, QStringLiteral("downloaded")));
+    QCOMPARE(spy.count(), 2);
+    QCOMPARE(testDb.scalarString(QStringLiteral(
+        "SELECT status FROM library_items WHERE id = %1").arg(addedId)),
+        QStringLiteral("downloaded"));
+
+    QVERIFY(service.removeBook(addedId));
+    QCOMPARE(spy.count(), 3);
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM library_items WHERE id = %1").arg(addedId)),
+        0);
+}
+
+QTEST_GUILESS_MAIN(LibraryServiceTest)
+
+#include "test_library_service.moc"

--- a/tests/integration/test_search_service.cpp
+++ b/tests/integration/test_search_service.cpp
@@ -1,0 +1,62 @@
+#include "gui/services/search_service.h"
+#include "support/test_database_utils.h"
+
+#include <QtTest>
+
+using namespace bookhub::gui;
+
+class SearchServiceTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void search_appliesAndSemanticsAcrossFilters();
+    void search_supportsAudiobookFilterAndSorting();
+};
+
+void SearchServiceTest::search_appliesAndSemanticsAcrossFilters()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open());
+    QVERIFY(testDb.createSchema());
+    QVERIFY(testDb.insertSampleData());
+
+    SearchService service;
+    SearchParams params;
+    params.keyword = QStringLiteral("Pride");
+    params.languages = {QStringLiteral("English")};
+    params.sources = {QStringLiteral("Gutenberg")};
+    params.genres = {QStringLiteral("Romance")};
+
+    const QList<SearchResult> results = service.search(params);
+    QCOMPARE(results.size(), 1);
+    QCOMPARE(results.first().bookId, QStringLiteral("lccn:n78095332"));
+}
+
+void SearchServiceTest::search_supportsAudiobookFilterAndSorting()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open());
+    QVERIFY(testDb.createSchema());
+    QVERIFY(testDb.insertSampleData());
+    QVERIFY(bookhub::tests::execSql(testDb.database(), QStringLiteral(
+        "UPDATE library_items SET status = 'audiobook_ready' WHERE book_id = 'lccn:n79025140'")));
+
+    SearchService service;
+    SearchParams audiobook;
+    audiobook.audiobookOnly = true;
+    const QList<SearchResult> audioResults = service.search(audiobook);
+    QCOMPARE(audioResults.size(), 1);
+    QCOMPARE(audioResults.first().bookId, QStringLiteral("lccn:n79025140"));
+
+    SearchParams sortByAuthor;
+    sortByAuthor.keyword = QStringLiteral(" ");
+    sortByAuthor.sortColumn = QStringLiteral("author");
+    const QList<SearchResult> sorted = service.search(sortByAuthor);
+    QVERIFY(sorted.size() >= 3);
+    QCOMPARE(sorted.first().author, QStringLiteral("Alexandre Dumas"));
+}
+
+QTEST_GUILESS_MAIN(SearchServiceTest)
+
+#include "test_search_service.moc"

--- a/tests/integration/test_search_service.cpp
+++ b/tests/integration/test_search_service.cpp
@@ -12,6 +12,7 @@ class SearchServiceTest : public QObject
 private slots:
     void search_appliesAndSemanticsAcrossFilters();
     void search_supportsAudiobookFilterAndSorting();
+    void search_escapesLikeWildcardsInKeyword();
 };
 
 void SearchServiceTest::search_appliesAndSemanticsAcrossFilters()
@@ -49,12 +50,50 @@ void SearchServiceTest::search_supportsAudiobookFilterAndSorting()
     QCOMPARE(audioResults.size(), 1);
     QCOMPARE(audioResults.first().bookId, QStringLiteral("lccn:n79025140"));
 
+    // No keyword — returns all books in the database ordered by author.
+    // Sample data has exactly 3 books; Alexandre Dumas sorts first alphabetically.
     SearchParams sortByAuthor;
-    sortByAuthor.keyword = QStringLiteral(" ");
     sortByAuthor.sortColumn = QStringLiteral("author");
     const QList<SearchResult> sorted = service.search(sortByAuthor);
-    QVERIFY(sorted.size() >= 3);
+    QCOMPARE(sorted.size(), 3);
     QCOMPARE(sorted.first().author, QStringLiteral("Alexandre Dumas"));
+}
+
+void SearchServiceTest::search_escapesLikeWildcardsInKeyword()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open());
+    QVERIFY(testDb.createSchema());
+
+    // "100% Complete" contains a literal '%'. Without escaping, searching for
+    // "100%" produces LIKE '%100%%', which also matches "1001 Adventures"
+    // because the unescaped '%' acts as a wildcard after "100".
+    // "A_B Catalogue" contains a literal '_'. Without escaping, searching for
+    // "A_B" produces LIKE '%A_B%', which also matches "ACB Compendium" because
+    // the unescaped '_' acts as a single-character wildcard.
+    QVERIFY(bookhub::tests::execSql(testDb.database(), QStringLiteral(
+        "INSERT INTO books (book_id, title, author) VALUES "
+        "('book:percent', '100% Complete',   'A'), "
+        "('book:wild',    '1001 Adventures', 'B'), "
+        "('book:under',   'A_B Catalogue',   'C'), "
+        "('book:any',     'ACB Compendium',  'D')")));
+    QVERIFY(bookhub::tests::execSql(testDb.database(), QStringLiteral(
+        "INSERT INTO editions (book_id, language) VALUES "
+        "('book:percent', 'English'), ('book:wild', 'English'), "
+        "('book:under', 'English'), ('book:any', 'English')")));
+
+    SearchService service;
+    SearchParams params;
+
+    params.keyword = QStringLiteral("100%");
+    const QList<SearchResult> percentResults = service.search(params);
+    QCOMPARE(percentResults.size(), 1);
+    QCOMPARE(percentResults.first().bookId, QStringLiteral("book:percent"));
+
+    params.keyword = QStringLiteral("A_B");
+    const QList<SearchResult> underResults = service.search(params);
+    QCOMPARE(underResults.size(), 1);
+    QCOMPARE(underResults.first().bookId, QStringLiteral("book:under"));
 }
 
 QTEST_GUILESS_MAIN(SearchServiceTest)

--- a/tests/support/test_database_utils.h
+++ b/tests/support/test_database_utils.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "database.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QTemporaryDir>
+
+namespace bookhub::tests {
+
+class TestDatabase
+{
+public:
+    TestDatabase() = default;
+    ~TestDatabase() { close(); }
+
+    bool open(const QString &name = QSqlDatabase::defaultConnection)
+    {
+        close();
+        connectionName = name;
+        filePath = tempDir.filePath(QStringLiteral("bookhub-test.db"));
+        QFile::remove(filePath);
+
+        if (!db::initializeDatabase(filePath, connectionName))
+            return false;
+
+        db = QSqlDatabase::database(connectionName);
+        return db.isOpen();
+    }
+
+    bool createSchema() const
+    {
+        return db::createSchema(connectionName);
+    }
+
+    bool insertSampleData() const
+    {
+        return db::insertSampleData(connectionName);
+    }
+
+    bool exec(const QString &sql) const
+    {
+        QSqlQuery query(db);
+        return query.exec(sql);
+    }
+
+    int scalarInt(const QString &sql) const
+    {
+        QSqlQuery query(db);
+        if (!query.exec(sql) || !query.next())
+            return -1;
+        return query.value(0).toInt();
+    }
+
+    QString scalarString(const QString &sql) const
+    {
+        QSqlQuery query(db);
+        if (!query.exec(sql) || !query.next())
+            return {};
+        return query.value(0).toString();
+    }
+
+    void close()
+    {
+        if (connectionName.isEmpty())
+            return;
+
+        const QString name = connectionName;
+        if (QSqlDatabase::contains(name)) {
+            db.close();
+            db = QSqlDatabase();
+            QSqlDatabase::removeDatabase(name);
+        }
+        connectionName.clear();
+        filePath.clear();
+    }
+
+    QSqlDatabase database() const { return db; }
+    QString connection() const { return connectionName; }
+
+private:
+    QTemporaryDir tempDir;
+    QString connectionName;
+    QString filePath;
+    QSqlDatabase db;
+};
+
+inline bool execSql(const QSqlDatabase &db, const QString &sql)
+{
+    QSqlQuery query(db);
+    return query.exec(sql);
+}
+
+inline void isolateSettings(const QString &dirName)
+{
+    const QString root = QDir::temp().filePath(dirName);
+    QDir().mkpath(root);
+    qputenv("XDG_CONFIG_HOME", root.toUtf8());
+}
+
+} // namespace bookhub::tests

--- a/tests/unit/test_database_schema.cpp
+++ b/tests/unit/test_database_schema.cpp
@@ -11,7 +11,8 @@ class DatabaseSchemaTest : public QObject
 private slots:
     void databaseFilePath_resolvesNextToExecutable();
     void createSchema_createsCoreTablesAndVersion();
-    void verifySchemaVersion_handlesFreshAndMismatch();
+    void verifySchemaVersion_freshDatabaseIsValid();
+    void verifySchemaVersion_mismatchedVersionIsRejected();
     void constraints_andSampleData_behaveAsExpected();
 };
 
@@ -35,12 +36,19 @@ void DatabaseSchemaTest::createSchema_createsCoreTablesAndVersion()
         8);
 }
 
-void DatabaseSchemaTest::verifySchemaVersion_handlesFreshAndMismatch()
+void DatabaseSchemaTest::verifySchemaVersion_freshDatabaseIsValid()
 {
+    // A database that has been opened but never had createSchema() called has
+    // user_version=0 and no tables. verifySchemaVersion treats this as a fresh,
+    // valid database — the caller is expected to call createSchema() immediately
+    // after receiving true from this check.
     bookhub::tests::TestDatabase freshDb;
     QVERIFY(freshDb.open());
     QVERIFY(db::verifySchemaVersion(freshDb.connection()));
+}
 
+void DatabaseSchemaTest::verifySchemaVersion_mismatchedVersionIsRejected()
+{
     bookhub::tests::TestDatabase mismatchDb;
     QVERIFY(mismatchDb.open(QStringLiteral("mismatch")));
     QVERIFY(mismatchDb.createSchema());

--- a/tests/unit/test_database_schema.cpp
+++ b/tests/unit/test_database_schema.cpp
@@ -1,0 +1,87 @@
+#include "support/test_database_utils.h"
+
+#include <QtTest>
+
+using namespace bookhub;
+
+class DatabaseSchemaTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void databaseFilePath_resolvesNextToExecutable();
+    void createSchema_createsCoreTablesAndVersion();
+    void verifySchemaVersion_handlesFreshAndMismatch();
+    void constraints_andSampleData_behaveAsExpected();
+};
+
+void DatabaseSchemaTest::databaseFilePath_resolvesNextToExecutable()
+{
+    const QString expected =
+        QDir(QCoreApplication::applicationDirPath()).filePath(QStringLiteral("bookhub.db"));
+    QCOMPARE(db::databaseFilePath(), expected);
+}
+
+void DatabaseSchemaTest::createSchema_createsCoreTablesAndVersion()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open());
+    QVERIFY(testDb.createSchema());
+
+    QCOMPARE(testDb.scalarInt(QStringLiteral("PRAGMA user_version")), db::kSchemaVersion);
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name IN "
+        "('books','book_identifiers','editions','genres','book_genres','formats','sources','library_items')")),
+        8);
+}
+
+void DatabaseSchemaTest::verifySchemaVersion_handlesFreshAndMismatch()
+{
+    bookhub::tests::TestDatabase freshDb;
+    QVERIFY(freshDb.open());
+    QVERIFY(db::verifySchemaVersion(freshDb.connection()));
+
+    bookhub::tests::TestDatabase mismatchDb;
+    QVERIFY(mismatchDb.open(QStringLiteral("mismatch")));
+    QVERIFY(mismatchDb.createSchema());
+    QVERIFY(bookhub::tests::execSql(mismatchDb.database(), QStringLiteral("PRAGMA user_version = 99")));
+    QVERIFY(!db::verifySchemaVersion(mismatchDb.connection()));
+}
+
+void DatabaseSchemaTest::constraints_andSampleData_behaveAsExpected()
+{
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open());
+    QVERIFY(testDb.createSchema());
+    QVERIFY(testDb.insertSampleData());
+    QVERIFY(testDb.insertSampleData());
+
+    QCOMPARE(testDb.scalarInt(QStringLiteral("SELECT COUNT(*) FROM books")), 3);
+    QCOMPARE(testDb.scalarInt(QStringLiteral("SELECT COUNT(*) FROM library_items")), 2);
+
+    QVERIFY(!bookhub::tests::execSql(testDb.database(), QStringLiteral(
+        "INSERT INTO book_identifiers (book_id, type, value) "
+        "VALUES ('lccn:n78095332', 'gutenberg', '1342')")));
+
+    QVERIFY(bookhub::tests::execSql(testDb.database(), QStringLiteral(
+        "UPDATE books SET book_id = 'lccn:updated' WHERE book_id = 'lccn:n78095332'")));
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM book_identifiers WHERE book_id = 'lccn:updated' AND type = 'gutenberg' AND value = '1342'")),
+        1);
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM library_items WHERE book_id = 'lccn:updated'")),
+        1);
+
+    QVERIFY(bookhub::tests::execSql(testDb.database(), QStringLiteral(
+        "DELETE FROM books WHERE book_id = 'lccn:updated'")));
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM book_identifiers WHERE book_id = 'lccn:updated'")),
+        0);
+    QCOMPARE(testDb.scalarInt(QStringLiteral(
+        "SELECT COUNT(*) FROM library_items WHERE book_id = 'lccn:updated'")),
+        0);
+}
+
+QTEST_GUILESS_MAIN(DatabaseSchemaTest)
+
+#include "test_database_schema.moc"

--- a/tests/unit/test_gutenberg_id_resolution.cpp
+++ b/tests/unit/test_gutenberg_id_resolution.cpp
@@ -1,0 +1,102 @@
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QList>
+#include <QMap>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+
+#define private public
+#include "collector/gutenberg_adapter.h"
+#undef private
+
+#include <QtTest>
+#include <algorithm>
+
+using namespace bookhub::collector;
+
+class GutenbergIdResolutionTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void normalizeLccn_handlesUriAndPadding();
+    void resolveBookId_honorsPriorityAndIsbnConversion();
+    void parseSingleRdf_ignoresImagesAndStoresIdentifiers();
+};
+
+void GutenbergIdResolutionTest::normalizeLccn_handlesUriAndPadding()
+{
+    QCOMPARE(GutenbergAdapter::normalizeLccn(QStringLiteral("http://id.loc.gov/authorities/names/n9530321")),
+             QStringLiteral("lccn:n09530321"));
+    QCOMPARE(GutenbergAdapter::normalizeLccn(QStringLiteral("lccn:2004045630")),
+             QStringLiteral("lccn:2004045630"));
+}
+
+void GutenbergIdResolutionTest::resolveBookId_honorsPriorityAndIsbnConversion()
+{
+    QCOMPARE(GutenbergAdapter::resolveBookId(
+                 {QStringLiteral("oclc:1234"), QStringLiteral("1234567890")},
+                 QStringLiteral("1342")),
+             QStringLiteral("oclc:1234"));
+
+    QCOMPARE(GutenbergAdapter::resolveBookId(
+                 {QStringLiteral("http://id.loc.gov/authorities/names/n78095332"),
+                  QStringLiteral("oclc:1234"),
+                  QStringLiteral("1234567890")},
+                 QStringLiteral("1342")),
+             QStringLiteral("lccn:n78095332"));
+
+    QCOMPARE(GutenbergAdapter::resolveBookId({}, QStringLiteral("1342")),
+             QStringLiteral("gutenberg:1342"));
+}
+
+void GutenbergIdResolutionTest::parseSingleRdf_ignoresImagesAndStoresIdentifiers()
+{
+    GutenbergAdapter adapter;
+    QList<DiscoveredBook> batch;
+    const auto hasIdentifier = [](const QList<BookIdentifier> &ids, const QString &type, const QString &value) {
+        return std::any_of(ids.begin(), ids.end(), [&](const BookIdentifier &id) {
+            return id.type == type && id.value == value;
+        });
+    };
+
+    const QByteArray rdf = R"(
+        <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+          <ebook rdf:about="https://www.gutenberg.org/ebooks/1342">
+            <title>Pride and Prejudice</title>
+            <creator>
+              <agent>
+                <name>Jane Austen</name>
+              </agent>
+            </creator>
+            <identifier>http://id.loc.gov/authorities/names/n78095332</identifier>
+            <identifier>1234567890</identifier>
+            <language><value>en</value></language>
+            <subject><value>Romance fiction</value></subject>
+            <file rdf:about="https://www.gutenberg.org/ebooks/1342.epub.images">
+              <format><value>application/epub+zip</value></format>
+            </file>
+            <file rdf:about="https://www.gutenberg.org/cache/epub/1342/cover.jpg">
+              <format><value>image/jpeg</value></format>
+            </file>
+          </ebook>
+        </rdf:RDF>
+    )";
+
+    adapter.parseSingleRdf(rdf, QStringLiteral("cache/epub/1342/pg1342.rdf"), batch);
+
+    QCOMPARE(batch.size(), 1);
+    const DiscoveredBook &book = batch.first();
+    QCOMPARE(book.sourceId, QStringLiteral("1342"));
+    QCOMPARE(book.resolvedId, QStringLiteral("lccn:n78095332"));
+    QVERIFY(book.formats.contains(QStringLiteral("epub_1")));
+    QVERIFY(!book.formats.values().contains(QStringLiteral("https://www.gutenberg.org/cache/epub/1342/cover.jpg")));
+    QVERIFY(hasIdentifier(book.identifiers, QStringLiteral("lccn"), QStringLiteral("n78095332")));
+    QVERIFY(hasIdentifier(book.identifiers, QStringLiteral("isbn"), QStringLiteral("9781234567897")));
+    QVERIFY(hasIdentifier(book.identifiers, QStringLiteral("gutenberg"), QStringLiteral("1342")));
+}
+
+QTEST_GUILESS_MAIN(GutenbergIdResolutionTest)
+
+#include "test_gutenberg_id_resolution.moc"

--- a/tools/migrate_db.py
+++ b/tools/migrate_db.py
@@ -5,10 +5,6 @@ migrate_db.py — Migrate bookhub.db from schema version 0 to version 1.
 Schema v0: ISBN-keyed books table.
 Schema v1: book_id-keyed books table with book_identifiers for cross-source deduplication.
 
-This script handles only the v0→v1 migration (a structural rewrite of the schema).
-The v1→v2 migration (adding UNIQUE constraints on formats, sources, and library_items)
-is handled automatically by the application at startup via verifySchemaVersion().
-
 All migration steps run inside a single transaction. PRAGMA user_version is set
 outside the transaction (SQLite requirement). On any failure the transaction is
 rolled back and the database is left untouched.
@@ -180,6 +176,17 @@ def migrate(db_path: str) -> None:
             con.close()
             sys.exit(1)
 
+        for sentinel in ("_old_formats", "_old_sources"):
+            if table_exists(cur, sentinel):
+                print(
+                    f"Error: table '{sentinel}' already exists. The database may be "
+                    "in an unknown partial-migration state. Restore from a backup "
+                    "before retrying.",
+                    file=sys.stderr,
+                )
+                con.close()
+                sys.exit(1)
+
         # --- Verify the old 'books' table has the expected 'isbn' column ------
         if table_exists(cur, "books") and not column_exists(cur, "books", "isbn"):
             print(
@@ -191,21 +198,25 @@ def migrate(db_path: str) -> None:
             con.close()
             sys.exit(1)
 
+        # Step 1: Disable FK enforcement — must be outside any active transaction.
+        con.execute("PRAGMA foreign_keys = OFF")
+
         # ======================================================================
         # BEGIN TRANSACTION
         # ======================================================================
         con.execute("BEGIN")
 
-        # Step 1: Disable foreign key enforcement for the duration of migration.
-        # NOTE: PRAGMA foreign_keys must be set outside any transaction to take
-        # effect, but SQLite silently accepts it inside one — it will apply after
-        # the next transaction boundary. We disable it here so that the rename +
-        # re-create sequence doesn't trip FK checks mid-migration.
-        con.execute("PRAGMA foreign_keys = OFF")
-
         # Step 2: Rename old tables to backup names.
+        # formats and sources are renamed alongside editions: SQLite's
+        # ALTER TABLE RENAME rewrites child FK definitions to point at the new
+        # parent name (_old_editions), so leaving formats in place would give it
+        # a broken FK after _old_editions is dropped.
         con.execute("ALTER TABLE books RENAME TO _old_books")
         con.execute("ALTER TABLE editions RENAME TO _old_editions")
+        if table_exists(cur, "formats"):
+            con.execute("ALTER TABLE formats RENAME TO _old_formats")
+        if table_exists(cur, "sources"):
+            con.execute("ALTER TABLE sources RENAME TO _old_sources")
         con.execute("ALTER TABLE book_genres RENAME TO _old_book_genres")
         con.execute("ALTER TABLE library_items RENAME TO _old_library_items")
 
@@ -213,8 +224,6 @@ def migrate(db_path: str) -> None:
         con.execute(NEW_BOOKS_DDL)
         con.execute(NEW_BOOK_IDENTIFIERS_DDL)
         con.execute(NEW_EDITIONS_DDL)
-        # genres, formats, sources schema is unchanged — recreate defensively
-        # using IF NOT EXISTS so existing data is preserved.
         con.execute(NEW_GENRES_DDL)
         con.execute(NEW_BOOK_GENRES_DDL)
         con.execute(NEW_FORMATS_DDL)
@@ -317,20 +326,81 @@ def migrate(db_path: str) -> None:
         )
         print(f"Migrated {len(library_rows)} library_items")
 
-        # Step 10: Drop backup tables.
+        # Step 10: Migrate formats. MIN(id) picks a stable representative row when
+        # the old schema allowed duplicate (edition_id, format_type) pairs that the
+        # restored UNIQUE constraint now forbids.
+        if table_exists(cur, "_old_formats"):
+            cur.execute("""
+                SELECT MIN(id) AS id, edition_id, format_type
+                FROM _old_formats
+                GROUP BY edition_id, format_type
+            """)
+            old_formats = cur.fetchall()
+            format_rows = [
+                (row["id"], row["edition_id"], row["format_type"])
+                for row in old_formats
+            ]
+            con.executemany(
+                "INSERT INTO formats (id, edition_id, format_type) VALUES (?, ?, ?)",
+                format_rows,
+            )
+            print(f"Migrated {len(format_rows)} formats")
+
+        # Step 11: Migrate sources. MIN(id) picks a stable representative row when
+        # the old schema allowed duplicate (format_id, source_name) pairs that the
+        # restored UNIQUE constraint now forbids. download_link from the earliest row
+        # is kept; for true duplicates it will be identical.
+        if table_exists(cur, "_old_sources"):
+            cur.execute("""
+                SELECT MIN(id) AS id, format_id, source_name,
+                       MIN(download_link) AS download_link
+                FROM _old_sources
+                GROUP BY format_id, source_name
+            """)
+            old_sources = cur.fetchall()
+            source_rows = [
+                (row["id"], row["format_id"], row["source_name"], row["download_link"])
+                for row in old_sources
+            ]
+            con.executemany(
+                "INSERT INTO sources (id, format_id, source_name, download_link) "
+                "VALUES (?, ?, ?, ?)",
+                source_rows,
+            )
+            print(f"Migrated {len(source_rows)} sources")
+
+        # Step 12: Drop backup tables.
+        if table_exists(cur, "_old_sources"):
+            con.execute("DROP TABLE _old_sources")
+        if table_exists(cur, "_old_formats"):
+            con.execute("DROP TABLE _old_formats")
         con.execute("DROP TABLE _old_library_items")
         con.execute("DROP TABLE _old_book_genres")
         con.execute("DROP TABLE _old_editions")
         con.execute("DROP TABLE _old_books")
 
-        # Step 11: Re-enable foreign keys.
-        con.execute("PRAGMA foreign_keys = ON")
-
-        # Step 12: Commit transaction.
+        # Step 13: Commit transaction.
         con.execute("COMMIT")
 
-        # Step 13: Set user_version OUTSIDE the transaction (SQLite requirement).
-        con.execute("PRAGMA user_version = 1")
+        # Steps 14-15: Re-enable FK enforcement and stamp the version — both
+        # must be outside an active transaction (SQLite requirement).
+        con.execute("PRAGMA foreign_keys = ON")
+
+        # Stamp the version in a separate try block: if COMMIT succeeded but this
+        # fails, the schema is correct but user_version is still 0, so the migration
+        # would re-run on next launch. Surface a clear recovery instruction rather
+        # than silently leaving the DB in an ambiguous state.
+        try:
+            con.execute("PRAGMA user_version = 1")
+        except Exception as exc:
+            print(
+                f"Error: migration committed but version stamp failed: {exc}\n"
+                "The schema is correct. Run the following to fix the version:\n"
+                "  sqlite3 bookhub.db 'PRAGMA user_version = 1'",
+                file=sys.stderr,
+            )
+            con.close()
+            sys.exit(1)
 
         print("Migration complete. user_version set to 1.")
 

--- a/tools/migrate_db.py
+++ b/tools/migrate_db.py
@@ -5,6 +5,10 @@ migrate_db.py — Migrate bookhub.db from schema version 0 to version 1.
 Schema v0: ISBN-keyed books table.
 Schema v1: book_id-keyed books table with book_identifiers for cross-source deduplication.
 
+This script handles only the v0→v1 migration (a structural rewrite of the schema).
+The v1→v2 migration (adding UNIQUE constraints on formats, sources, and library_items)
+is handled automatically by the application at startup via verifySchemaVersion().
+
 All migration steps run inside a single transaction. PRAGMA user_version is set
 outside the transaction (SQLite requirement). On any failure the transaction is
 rolled back and the database is left untouched.
@@ -74,6 +78,7 @@ CREATE TABLE IF NOT EXISTS formats (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     edition_id INTEGER NOT NULL,
     format_type TEXT NOT NULL,
+    UNIQUE(edition_id, format_type),
     FOREIGN KEY (edition_id) REFERENCES editions(id) ON DELETE CASCADE
 )
 """
@@ -84,6 +89,7 @@ CREATE TABLE IF NOT EXISTS sources (
     format_id INTEGER NOT NULL,
     source_name TEXT NOT NULL,
     download_link TEXT NOT NULL,
+    UNIQUE(format_id, source_name),
     FOREIGN KEY (format_id) REFERENCES formats(id) ON DELETE CASCADE
 )
 """
@@ -91,7 +97,7 @@ CREATE TABLE IF NOT EXISTS sources (
 NEW_LIBRARY_ITEMS_DDL = """
 CREATE TABLE IF NOT EXISTS library_items (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    book_id TEXT NOT NULL,
+    book_id TEXT NOT NULL UNIQUE,
     edition_id INTEGER,
     added_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     status TEXT,
@@ -151,8 +157,15 @@ def migrate(db_path: str) -> None:
         cur.execute("PRAGMA user_version")
         user_version = cur.fetchone()[0]
 
-        if user_version >= 1:
-            print("already at version 1, nothing to do")
+        if user_version == 1:
+            print(
+                "Database is at v1. Launch the app once to auto-migrate to v2."
+            )
+            con.close()
+            return
+
+        if user_version >= 2:
+            print("Already at version 2 (or newer), nothing to do.")
             con.close()
             return
 
@@ -342,7 +355,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=(
             "Migrate bookhub.db from schema version 0 (ISBN-keyed) "
-            "to version 1 (book_id-keyed)."
+            "to version 1 (book_id-keyed). "
+            "The v1→v2 migration is handled automatically by the app at startup."
         )
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

- Fix shutdown crash: replace `QPointer<BookDiscoveryService>` as invokeMethod target with a thread-local `QObject threadContext` stack object owned by `run()`, eliminating the cross-thread `QPointer` access that caused the crash. Make `m_threadContext` `std::atomic<QObject*>` to eliminate the data race between the GUI and collector threads on shutdown.
- Fix SQL injection via LIKE wildcards: add `escapeLike()` helper escaping `%`, `_`, `\` in keyword/author inputs; add `ESCAPE '\'` to all LIKE clauses; whitelist `sortColumn` to prevent order-by injection.
- Fix unbounded duplicate rows: add `UNIQUE(edition_id, format_type)` on `formats`, `UNIQUE(format_id, source_name)` on `sources`, and `UNIQUE(book_id)` on `library_items`; bump schema to version 2 with automatic in-app migration and updated `migrate_db.py`.
- Fix duplicate detection in `addBook`: use `INSERT OR IGNORE` + `numRowsAffected() <= 0` guard; suppress spurious `libraryChanged()` emit on no-op insert.
- Fix `startDiscovery()` concurrent-run guard, fatal DB error UI, WAL journal mode, and ~20 minor code quality items.
- Add full test suite: 10 ctest targets (unit, integration, GUI) covering schema, ID resolution, discovery service, library/search/explore services, and all three screens.

## Test plan

- [ ] CI passes (build + all ctest targets)
- [ ] App launches cleanly; no shutdown crash on window close
- [ ] Search with `%` or `_` in the keyword box returns correct results, not all rows
- [ ] Running the collector twice does not accumulate duplicate `formats`/`sources` rows (verify with `sqlite3 bookhub.db 'SELECT COUNT(*) FROM formats'`)
- [ ] Fresh install (no existing DB) creates schema at version 2
- [ ] Existing v1 DB is auto-migrated to v2 on first launch

🤖 Generated with [Claude Code](https://claude.ai/claude-code)