### PR TITLE
feat: multiplatform support (Task 19)

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,6 @@
+CompileFlags:
+  Remove:
+    - -fmodules-ts
+    - -fmodule-mapper=*
+    - -fdeps-format=*
+    - -fdeps-file=*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Cache apt packages
       uses: actions/cache@v5
@@ -63,7 +63,7 @@ jobs:
 
     - name: Upload build artifact
       if: success()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: bookhub-${{ github.sha }}
         path: build/bookhub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: build
-        key: cmake-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'src/**') }}
+        key: cmake-${{ runner.os }}-${{ hashFiles('CMakeLists.txt', 'src/**', 'resources.qrc', '*.jpg', '*.png') }}
         restore-keys: cmake-${{ runner.os }}-
 
     - name: Configure build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ The app runs two threads in one process:
 - **GUI Thread** — `QApplication::exec()` drives a `QMainWindow`. All widget interaction happens here.
 - **Collector Thread** — `CollectorWorker : QThread` polls for book metadata every 10 minutes and writes to SQLite. Starts fetching immediately on launch.
 
-Both threads share a single SQLite database (`bookhub.db`, placed next to the executable). Thread isolation is maintained by giving each thread its own named Qt SQL connection: `QSqlDatabase::defaultConnection` for the GUI and `"collector_connection"` for the collector.
+Both threads share a single SQLite database (`bookhub.db`, stored in `QStandardPaths::AppDataLocation`). Thread isolation is maintained by giving each thread its own named Qt SQL connection: `QSqlDatabase::defaultConnection` for the GUI and `"collector_connection"` for the collector.
 
 ### Data Source Adapter Pattern
 
@@ -98,7 +98,7 @@ Full ID model: `docs/design/book-identity-model.md`. Schema DDL: `src/shared/dat
 - **Shutdown coordination:** Uses `std::atomic_bool` flags (`m_shutdownRequested`, `m_updateInProgress`) and a mix of `Qt::QueuedConnection` / `Qt::DirectConnection` for safe cross-thread teardown.
 - **Comments:** Explain *why*, not *what*. Use tags: `TODO:`, `FIXME:`, `HACK:`, `NOTE:`, `WARNING:`, `PERF:`, `SECURITY:`.
 - **Git workflow:** Every piece of work — feature, bugfix, or chore — gets its own short-lived branch cut from `develop` (e.g. `feature/task-7-search-screen`, `fix/collector-crash`, `chore/update-deps`). Keep branches small and focused: one task per branch. Merge back to `develop` via PR; never commit directly to `develop` or `master`. Both branches are protected and require PRs (0 approvals — bump to 1 in GitHub settings when a second contributor joins). **Before creating a PR, always run `/review` to perform a code review of the branch changes and address any issues found.** The only permitted path into `master` is a PR from `develop` — this is enforced both by the `.githooks/pre-push` hook (local) and GitHub branch protection (server-side). No other branch may target `master` directly.
-- **Build artifacts:** The icon and database are co-located with the executable via a CMake `POST_BUILD` copy. The `build/` directory is git-ignored.
+- **Build artifacts:** The icon is embedded as a Qt resource (`.qrc`). The database is stored in `QStandardPaths::AppDataLocation`. The `build/` directory is git-ignored.
 - **Docs:** When changing a public API, adding a feature, or altering architecture, update the relevant files in `docs/`. The `docs/` directory is for internal use and will be removed before release.
 - **License:** All third-party dependencies must be MIT, BSD, Apache 2.0, or similarly permissive. GPL and LGPL dependencies are forbidden — they would force the application to be GPL-licensed. Always verify a library's license before adding it. TTS uses [Sherpa-ONNX](https://github.com/k2-fsa/sherpa-onnx) (Apache 2.0) for preset voices and [PocketTTS.cpp](https://github.com/VolgaGerm/PocketTTS.cpp) (MIT) for custom voice cloning. Do not introduce the Piper GPL fork (`OHF-Voice/piper1-gpl`).
 - **QProcess:** Do not use `QProcess` anywhere in the codebase. The earlier `tar` subprocess in `GutenbergAdapter` was replaced with a direct libarchive link. Prefer linking against libraries directly, using Qt's networking/IO APIs, or `QThread`/`QThreadPool` for background work.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-# Ubuntu/Debian Qt6 install path fallback
-list(APPEND CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/cmake")
 find_package(Qt6 COMPONENTS Widgets Sql Network Test REQUIRED)
 find_package(LibArchive REQUIRED)
 
@@ -47,19 +45,12 @@ set(GUI_SOURCES
 
 add_executable(bookhub
     src/main.cpp
+    resources.qrc
     ${COLLECTOR_SOURCES}
     ${GUI_SOURCES}
 )
 target_include_directories(bookhub PRIVATE src)
 target_link_libraries(bookhub PRIVATE Qt6::Widgets Qt6::Network shared LibArchive::LibArchive)
-
-# Copy icon next to the executable after every build (mirrors database co-location pattern)
-add_custom_command(TARGET bookhub POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${CMAKE_SOURCE_DIR}/book_reader_icon.jpg"
-        "$<TARGET_FILE_DIR:bookhub>/book_reader_icon.jpg"
-    COMMENT "Copying book_reader_icon.jpg next to executable"
-)
 
 enable_testing()
 

--- a/docs/design/multiplatform-support.md
+++ b/docs/design/multiplatform-support.md
@@ -1,0 +1,94 @@
+# Multiplatform Support
+
+This document describes changes required to support multiple platforms (beyond Ubuntu/Linux).
+
+## Current Limitations
+
+The application currently has several hardcoded paths that assume:
+
+- Unix-like filesystem with executable co-located with mutable data
+- x86_64 architecture on Linux
+- SQLite database stored next to the executable
+
+## Required Changes
+
+### 1. Database Location
+
+**File:** `src/shared/database.cpp:15`
+
+```cpp
+// Current (fails on Windows/macOS due to sandboxing):
+return QDir(QCoreApplication::applicationDirPath()).filePath(kDatabaseFileName);
+
+// Multiplatform (cross-platform):
+return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/" + kDatabaseFileName;
+```
+
+**Rationale:** Modern OS sandboxing (especially Windows UAP/code signing, macOS App Sandbox) prevents writing to the executable's directory. `QStandardPaths::AppDataLocation` provides the proper platform-specific location.
+
+### 2. Icon Path
+
+**File:** `src/main.cpp:31`
+
+```cpp
+// Current:
+QDir(QCoreApplication::applicationDirPath()).filePath(QStringLiteral("book_reader_icon.jpg"));
+
+// Multiplatform:
+QDir(QCoreApplication::applicationDirPath() + "/..").filePath(QStringLiteral("book_reader_icon.jpg"));
+// Or better: embed as Qt resources (see below)
+```
+
+**Alternative:** Consider embedding the icon as a Qt resource (`.qrc` file) instead of a filesystem copy. This eliminates platform-specific path issues entirely.
+
+### 3. CMake Qt6 Path Fallback
+
+**File:** `CMakeLists.txt:11-12`
+
+```cmake
+# Current (x86_64 only):
+list(APPEND CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/cmake")
+
+# Multiplatform:
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    list(APPEND CMAKE_PREFIX_PATH "/usr/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/cmake")
+endif()
+```
+
+**Note:** The best approach is to remove this fallback entirely and rely on CMake's default search paths. Only add if Qt6 cannot be found.
+
+## Platform-Specific Dependencies
+
+| Platform | Qt6 Package | libarchive | Build Tool |
+|----------|------------|------------|------------|
+| Ubuntu/Debian | `qt6-base-dev libqt6sql6` | `libarchive-dev` | CMake |
+| Windows (MSVC) | Qt6 MSVC installer | vcpkg or prebuilt | CMake + MSVC |
+| Windows (MinGW) | Qt6 MinGW installer | vcpkg or prebuilt | CMake + MinGW |
+| macOS (Intel) | Homebrew `qt6` | `libarchive` (brew) | CMake |
+| macOS (Apple Silicon) | Homebrew `qt6` | `libarchive` (brew) | CMake |
+
+## Recommended Approach
+
+1. **Use Qt resources for icons** — Eliminates one path issue entirely
+2. **Use QStandardPaths** — All mutable data goes to platform-appropriate locations
+3. **Remove hardcoded CMake paths** — Let CMake find Qt6 via standard means
+4. **Consider vcpkg** — For consistent Windows dependency management
+
+## Documentation Updates Required After Implementation
+
+These files contain Linux-specific statements that will become stale once Task 19 changes are applied:
+
+| File | Location | Stale Statement | Replacement |
+|------|----------|-----------------|-------------|
+| `CLAUDE.md` | Two-Thread Model section | "Both threads share a single SQLite database (`bookhub.db`, placed next to the executable)" | Note that the database is stored in `QStandardPaths::AppDataLocation` |
+| `CLAUDE.md` | Key Conventions → Build artifacts | "The icon and database are co-located with the executable via a CMake `POST_BUILD` copy" | Icon is embedded as a Qt resource (`.qrc`); database lives in `AppDataLocation` |
+| `docs/design/test-strategy.md` | Database helpers section (line 156) | "`databaseFilePath()` resolves next to the executable" | Resolves to `QStandardPaths::AppDataLocation` |
+
+**Note:** References to `build/bookhub.db` in `docs/tasks/book-identity-model-implementation.md` are developer migration tooling context and do not need updating — developers still run migrations from the build directory.
+
+## Future Considerations
+
+- **macOS code signing:** May require entitlements for network access
+- **Windows Store deployment:** Requires specific sandboxing compliance
+- **Flatpak/Snap:** Alternative Linux distribution with sandboxing
+- **AppImage:** Portable single-file distribution (no sandboxing issues)

--- a/docs/design/test-strategy.md
+++ b/docs/design/test-strategy.md
@@ -153,7 +153,7 @@ foundation for future planned screens.
 
 ### Database helpers
 
-- `databaseFilePath()` resolves next to the executable.
+- `databaseFilePath()` resolves to `QStandardPaths::AppDataLocation`.
 - `createSchema()` creates all expected tables.
 - `insertSampleData()` is idempotent enough for repeated local startup use.
 

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,0 +1,6 @@
+<!DOCTYPE RCC>
+<RCC version="1.0">
+    <qresource prefix="/">
+        <file>book_reader_icon.jpg</file>
+    </qresource>
+</RCC>

--- a/spec/spec-architecture-multiplatform-support.md
+++ b/spec/spec-architecture-multiplatform-support.md
@@ -1,0 +1,183 @@
+---
+title: Multiplatform Support (Task 19)
+version: 1.0
+date_created: 2026-04-25
+tags: [cmake, qt6, platform, database, icon, resources]
+---
+
+# Introduction
+
+BookHub currently hard-codes Linux x86_64 assumptions for the database location, icon
+path, and CMake dependency search path. This spec defines the exact changes required to
+make the application build and run correctly on Windows and macOS without platform-specific
+source branches.
+
+## 1. Purpose & Scope
+
+Covers three code changes and one documentation update pass that together eliminate all
+Linux-specific assumptions from the build system and runtime:
+
+1. Database file path resolution (`src/shared/database.cpp`)
+2. Application icon delivery (`src/main.cpp`, `CMakeLists.txt`, new `.qrc` file)
+3. CMake Qt6 search path (`CMakeLists.txt`)
+4. Documentation corrections (`CLAUDE.md`, `docs/design/test-strategy.md`)
+
+Out of scope: installer/packaging, code-signing entitlements, CI runners on non-Linux
+platforms (those belong to a future packaging task).
+
+## 2. Definitions
+
+| Term | Meaning |
+|------|---------|
+| `AppDataLocation` | `QStandardPaths::AppDataLocation` — the platform-appropriate writable directory for application data (e.g. `~/.local/share/BookHub` on Linux, `%APPDATA%\BookHub` on Windows, `~/Library/Application Support/BookHub` on macOS) |
+| `.qrc` | Qt resource collection file; sources are compiled into the executable by `CMAKE_AUTORCC` |
+| `POST_BUILD` copy | CMake custom command that copies a file next to the executable after each build |
+| `AUTORCC` | CMake variable (`CMAKE_AUTORCC ON`) that auto-processes `.qrc` files |
+
+## 3. Requirements, Constraints & Guidelines
+
+- **REQ-001**: `bookhub::db::databaseFilePath()` must return a path inside `QStandardPaths::AppDataLocation` on all platforms, not next to the executable.
+- **REQ-002**: The directory returned by `QStandardPaths::AppDataLocation` must be created if it does not exist before the database is opened.
+- **REQ-003**: The application icon must be embedded in the executable as a Qt resource and loaded via the `:/` resource path — no filesystem path, no `POST_BUILD` copy.
+- **REQ-004**: The hardcoded `/usr/lib/x86_64-linux-gnu/cmake` CMake prefix path must be removed from `CMakeLists.txt`.
+- **REQ-005**: `QApplication::organizationName()` and `QApplication::applicationName()` must be set in `main()` before any `QStandardPaths` call so the platform path is computed correctly.
+- **CON-001**: `CMAKE_AUTORCC` is already `ON` in `CMakeLists.txt` — no CMake flag changes are needed to enable resource compilation.
+- **CON-002**: `book_reader_icon.jpg` is a JPEG. Qt resources support JPEG natively; no conversion is needed.
+- **CON-003**: Do not use `QProcess` anywhere (project-wide rule). Icon embedding must not shell out.
+- **GUD-001**: Prefer removing the CMake prefix path outright over conditionalising it. The path is only needed on misconfigured systems; standard Qt6 installs (apt, Homebrew, vcpkg, Qt installer) place `Qt6Config.cmake` in CMake's default search paths.
+- **GUD-002**: `QStandardPaths::AppDataLocation` requires `QCoreApplication::organizationName` and `QCoreApplication::applicationName` to be set; otherwise the path degenerates to the executable directory on some platforms.
+
+## 4. Interfaces & Data Contracts
+
+### 4.1 `bookhub::db::databaseFilePath()` — after change
+
+**File:** `src/shared/database.cpp`
+
+```cpp
+#include <QStandardPaths>
+#include <QDir>
+
+QString databaseFilePath()
+{
+    const QString dir =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir{}.mkpath(dir);   // create if absent — no-op if already exists
+    return QDir(dir).filePath(kDatabaseFileName);
+}
+```
+
+The `#include <QCoreApplication>` and `#include <QDir>` headers are already present; add
+`#include <QStandardPaths>`.
+
+### 4.2 Application identity — `main()` before any `QStandardPaths` call
+
+**File:** `src/main.cpp`
+
+```cpp
+QApplication app(argc, argv);
+app.setOrganizationName(QStringLiteral("BookHub"));
+app.setApplicationName(QStringLiteral("BookHub"));
+// ... rest of main
+```
+
+Both calls must appear immediately after `QApplication app(argc, argv);` and before
+`bookhub::db::initializeDatabase(...)`.
+
+### 4.3 Qt resource file
+
+**New file:** `resources.qrc` (project root, alongside `CMakeLists.txt`)
+
+```xml
+<!DOCTYPE RCC>
+<RCC version="1.0">
+    <qresource prefix="/">
+        <file>book_reader_icon.jpg</file>
+    </qresource>
+</RCC>
+```
+
+Resource path exposed to C++: `":/book_reader_icon.jpg"`
+
+### 4.4 Icon loading — `main()` after change
+
+**File:** `src/main.cpp`
+
+```cpp
+// Remove:
+const QString iconPath =
+    QDir(QCoreApplication::applicationDirPath()).filePath(QStringLiteral("book_reader_icon.jpg"));
+const QIcon appIcon(iconPath);
+
+// Replace with:
+const QIcon appIcon(QStringLiteral(":/book_reader_icon.jpg"));
+```
+
+The `#include <QDir>` and `#include <QCoreApplication>` imports in `main.cpp` may be
+removed if they are no longer used elsewhere in the file after this change.
+
+### 4.5 CMakeLists.txt — resource file registration and prefix path removal
+
+**Remove lines 11–12:**
+```cmake
+# Ubuntu/Debian Qt6 install path fallback
+list(APPEND CMAKE_PREFIX_PATH "/usr/lib/x86_64-linux-gnu/cmake")
+```
+
+**Add `resources.qrc` to the `bookhub` executable sources:**
+```cmake
+add_executable(bookhub
+    src/main.cpp
+    resources.qrc          # <-- add this line
+    ${COLLECTOR_SOURCES}
+    ${GUI_SOURCES}
+)
+```
+
+**Remove the `POST_BUILD` icon copy command (lines 57–62):**
+```cmake
+# Delete this entire block:
+add_custom_command(TARGET bookhub POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_SOURCE_DIR}/book_reader_icon.jpg"
+        "$<TARGET_FILE_DIR:bookhub>/book_reader_icon.jpg"
+    COMMENT "Copying book_reader_icon.jpg next to executable"
+)
+```
+
+## 5. Acceptance Criteria
+
+- **AC-001**: Given a clean build on Linux (non-x86_64, e.g. aarch64), When `cmake .. && make`, Then the build succeeds without the x86_64 path fallback.
+- **AC-002**: Given a fresh run of the application, When it starts for the first time on any platform, Then `bookhub.db` is created inside `QStandardPaths::AppDataLocation`, not next to the executable.
+- **AC-003**: Given no `book_reader_icon.jpg` file next to the executable, When the application starts, Then the window and taskbar still show the icon (loaded from the embedded resource).
+- **AC-004**: Given a build directory without `book_reader_icon.jpg` copied into it, When the build completes, Then no `POST_BUILD` copy step appears in the build log.
+- **AC-005**: Given `app.setOrganizationName` and `app.setApplicationName` are set before `databaseFilePath()` is called, When the path is resolved on macOS, Then it resolves to `~/Library/Application Support/BookHub/bookhub.db`.
+
+## 6. Rationale & Context
+
+- **Database path:** Writing next to the executable fails under Windows UAP sandboxing, macOS App Sandbox, and Flatpak/Snap on Linux. `QStandardPaths::AppDataLocation` is the Qt-idiomatic answer and is tested across all three desktop platforms.
+- **Icon as resource:** A `POST_BUILD` copy is fragile — it breaks if the build directory is wiped, the file is renamed, or the app is run from a different directory. Embedding eliminates the dependency entirely.
+- **CMake prefix path:** The `/usr/lib/x86_64-linux-gnu/cmake` path was added as a workaround for misconfigured Ubuntu installs. Standard Qt6 apt packages place `Qt6Config.cmake` in CMake's default search paths. Keeping it silently breaks cross-compilation and non-x86 Linux builds.
+
+## 7. Dependencies
+
+| Dependency | Notes |
+|-----------|-------|
+| Qt6 Core (`QStandardPaths`) | Already linked via `Qt6::Widgets` → `Qt6::Core` |
+| `CMAKE_AUTORCC ON` | Already set in `CMakeLists.txt` line 9 |
+| `book_reader_icon.jpg` | Must remain at the project root for `.qrc` to reference it |
+
+## 8. Documentation Updates After Implementation
+
+Apply these after the code changes are merged:
+
+| File | Location | Old text | New text |
+|------|----------|----------|----------|
+| `CLAUDE.md` | Two-Thread Model section | "Both threads share a single SQLite database (`bookhub.db`, placed next to the executable)" | "Both threads share a single SQLite database (`bookhub.db`, stored in `QStandardPaths::AppDataLocation`)" |
+| `CLAUDE.md` | Key Conventions → Build artifacts | "The icon and database are co-located with the executable via a CMake `POST_BUILD` copy." | "The icon is embedded as a Qt resource (`.qrc`). The database is stored in `QStandardPaths::AppDataLocation`." |
+| `docs/design/test-strategy.md` | Database helpers section (line 156) | "`databaseFilePath()` resolves next to the executable." | "`databaseFilePath()` resolves to `QStandardPaths::AppDataLocation`." |
+
+## 9. Related Specifications
+
+- `docs/design/multiplatform-support.md` — design doc this spec is derived from
+- `docs/tasks/task-breakdown.md` — Task 19 description
+- `docs/tasks/status.md` — Task 19 status

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include <QApplication>
 #include <QIcon>
-#include <QDir>
 #include <QMessageBox>
 #include "shared/database.h"
 #include "collector/collector_worker.h"
@@ -9,6 +8,8 @@
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+    app.setOrganizationName(QStringLiteral("BookHub"));
+    app.setApplicationName(QStringLiteral("BookHub"));
 
     if (!bookhub::db::initializeDatabase(bookhub::db::databaseFilePath())) {
         QMessageBox::critical(nullptr,
@@ -27,9 +28,7 @@ int main(int argc, char *argv[])
     bookhub::collector::CollectorWorker collector;
     collector.start();
 
-    const QString iconPath =
-        QDir(QCoreApplication::applicationDirPath()).filePath(QStringLiteral("book_reader_icon.jpg"));
-    const QIcon appIcon(iconPath);
+    const QIcon appIcon(QStringLiteral(":/book_reader_icon.jpg"));
     app.setWindowIcon(appIcon);
 
     bookhub::gui::MainWindow window;

--- a/src/shared/database.cpp
+++ b/src/shared/database.cpp
@@ -1,6 +1,7 @@
 #include "database.h"
 #include <QCoreApplication>
 #include <QDir>
+#include <QStandardPaths>
 #include <QSqlDatabase>
 #include <QSqlError>
 #include <QSqlQuery>
@@ -12,7 +13,10 @@ static const QString kDatabaseFileName = QStringLiteral("bookhub.db");
 
 QString databaseFilePath()
 {
-    return QDir(QCoreApplication::applicationDirPath()).filePath(kDatabaseFileName);
+    const QString dir =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir{}.mkpath(dir);
+    return QDir(dir).filePath(kDatabaseFileName);
 }
 
 bool initializeDatabase(const QString &filePath, const QString &connectionName)

--- a/tests/unit/test_database_schema.cpp
+++ b/tests/unit/test_database_schema.cpp
@@ -1,5 +1,6 @@
 #include "support/test_database_utils.h"
 
+#include <QStandardPaths>
 #include <QtTest>
 
 using namespace bookhub;
@@ -9,17 +10,18 @@ class DatabaseSchemaTest : public QObject
     Q_OBJECT
 
 private slots:
-    void databaseFilePath_resolvesNextToExecutable();
+    void databaseFilePath_resolvesToAppDataLocation();
     void createSchema_createsCoreTablesAndVersion();
     void verifySchemaVersion_freshDatabaseIsValid();
     void verifySchemaVersion_mismatchedVersionIsRejected();
     void constraints_andSampleData_behaveAsExpected();
 };
 
-void DatabaseSchemaTest::databaseFilePath_resolvesNextToExecutable()
+void DatabaseSchemaTest::databaseFilePath_resolvesToAppDataLocation()
 {
-    const QString expected =
-        QDir(QCoreApplication::applicationDirPath()).filePath(QStringLiteral("bookhub.db"));
+    const QString expected = QDir(
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))
+        .filePath(QStringLiteral("bookhub.db"));
     QCOMPARE(db::databaseFilePath(), expected);
 }
 


### PR DESCRIPTION
## Summary

- Replace `QCoreApplication::applicationDirPath()` database path with `QStandardPaths::AppDataLocation`, fixing write failures under Windows UAP sandboxing, macOS App Sandbox, and Flatpak/Snap
- Embed `book_reader_icon.jpg` as a Qt resource (`.qrc`) and load via `:/book_reader_icon.jpg`, eliminating the fragile `POST_BUILD` filesystem copy
- Remove hardcoded `/usr/lib/x86_64-linux-gnu/cmake` prefix path that broke cross-compilation and non-x86 Linux builds
- Set `organizationName` / `applicationName` before any `QStandardPaths` call so platform paths resolve correctly
- Add `.clangd` config to suppress GCC module-scanning flags that clangd misreports as errors
- Update CI cache key to include `resources.qrc` and icon globs so embedded-resource changes invalidate the cache
- Update `CLAUDE.md`, `docs/design/test-strategy.md`, and `docs/design/multiplatform-support.md` to reflect new paths

## Test plan

- [ ] Clean build succeeds on Linux: `mkdir -p build && cd build && cmake .. && make -j$(nproc)`
- [ ] `bookhub.db` is created inside `~/.local/share/BookHub/` (not next to the executable) on first run
- [ ] Application window and taskbar show the icon with no `book_reader_icon.jpg` present next to the executable
- [ ] No `POST_BUILD copy` step appears in the build log
- [ ] clangd reports no false-positive `-fmodules-ts` diagnostics after restarting the language server

🤖 Generated with [Claude Code](https://claude.com/claude-code)