### PR TITLE
feat: BookDetailsPanel widget (Task 9)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,16 +31,18 @@ set(COLLECTOR_SOURCES
 
 set(GUI_SOURCES
     src/gui/main_window.cpp
+    src/gui/panels/book_details_panel.cpp
+    src/gui/screens/explore_screen.cpp
     src/gui/screens/library_screen.cpp
-    src/gui/widgets/book_card_delegate.cpp
-    src/gui/widgets/empty_state_widget.cpp
-    src/gui/widgets/badge_label.cpp
     src/gui/screens/search_screen.cpp
-    src/gui/widgets/search_result_delegate.cpp
+    src/gui/services/book_details_service.cpp
+    src/gui/services/explore_service.cpp
     src/gui/services/library_service.cpp
     src/gui/services/search_service.cpp
-    src/gui/screens/explore_screen.cpp
-    src/gui/services/explore_service.cpp
+    src/gui/widgets/badge_label.cpp
+    src/gui/widgets/book_card_delegate.cpp
+    src/gui/widgets/empty_state_widget.cpp
+    src/gui/widgets/search_result_delegate.cpp
     src/gui/query_worker.cpp
 )
 
@@ -118,3 +120,8 @@ add_bookhub_test(test_explore_screen
     tests/gui/test_explore_screen.cpp
 )
 label_bookhub_test(test_explore_screen gui explore)
+
+add_bookhub_test(test_book_details_panel
+    tests/gui/test_book_details_panel.cpp
+)
+label_bookhub_test(test_book_details_panel sanity gui details)

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -1,4 +1,5 @@
 #include "main_window.h"
+#include "panels/book_details_panel.h"
 #include "query_worker.h"
 #include "screens/explore_screen.h"
 #include "screens/library_screen.h"
@@ -11,6 +12,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <QSplitter>
 #include <QStackedWidget>
 #include <QStatusBar>
 #include <QThread>
@@ -64,37 +66,48 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   buildNavBar();
   root->addWidget(m_navBar);
 
-  // Content stack
-  m_stack = new QStackedWidget(central);
-  root->addWidget(m_stack, 1);
+  // Content splitter — left: screen stack, right: book details panel (hidden initially)
+  m_contentSplitter = new QSplitter(Qt::Horizontal, central);
+  m_contentSplitter->setHandleWidth(1);
+  m_contentSplitter->setChildrenCollapsible(false);
+  m_contentSplitter->setStyleSheet(
+      QStringLiteral("QSplitter::handle { background-color: %1; }").arg(ColorBorder));
+  root->addWidget(m_contentSplitter, 1);
+
+  // Screen stack (left pane)
+  m_stack = new QStackedWidget(m_contentSplitter);
+  m_contentSplitter->addWidget(m_stack);
 
   // Screen 0: Library
   m_libraryScreen = new LibraryScreen(m_libraryService, m_stack);
   connect(m_libraryScreen, &LibraryScreen::exploreRequested, this,
           &MainWindow::onLibraryExploreRequested);
-  connect(m_libraryScreen, &LibraryScreen::bookDetailsRequested, this,
-          [](const QString & /*bookId*/) {
-            // TODO: show BookDetailsPanel (Task 9)
-          });
+  connect(m_libraryScreen, &LibraryScreen::bookDetailsRequested,
+          this, &MainWindow::onBookDetailsRequested);
   m_stack->addWidget(m_libraryScreen); // index 0
 
   // Screen 1: Search — borrows the shared LibraryService
   m_searchScreen = new SearchScreen(m_libraryService, m_queryWorker, m_stack);
-  connect(m_searchScreen, &SearchScreen::bookDetailsRequested, this,
-          [](const QString & /*bookId*/) {
-            // TODO: show BookDetailsPanel (Task 9)
-          });
+  connect(m_searchScreen, &SearchScreen::bookDetailsRequested,
+          this, &MainWindow::onBookDetailsRequested);
   m_stack->addWidget(m_searchScreen); // index 1
 
   // Screen 2: Explore
   m_exploreScreen = new ExploreScreen(m_queryWorker, m_stack);
-  connect(m_exploreScreen, &ExploreScreen::bookDetailsRequested, this,
-          [](const QString & /*bookId*/) {
-            // TODO: show BookDetailsPanel (Task 9)
-          });
+  connect(m_exploreScreen, &ExploreScreen::bookDetailsRequested,
+          this, &MainWindow::onBookDetailsRequested);
   m_stack->addWidget(m_exploreScreen); // index 2
 
   m_stack->setCurrentIndex(0);
+
+  // Book details panel (right pane — hidden until a book is clicked)
+  m_bookDetailsPanel =
+      new BookDetailsPanel(m_libraryService, m_queryWorker, m_contentSplitter);
+  m_contentSplitter->addWidget(m_bookDetailsPanel);
+  m_bookDetailsPanel->hide();
+
+  connect(m_bookDetailsPanel, &BookDetailsPanel::dismissed,
+          this, &MainWindow::onBookDetailsDismissed);
 
   // Status bar
   buildStatusBar();
@@ -227,6 +240,19 @@ void MainWindow::onLibraryExploreRequested() {
   if (auto *btn = qobject_cast<QPushButton *>(m_navGroup->button(2))) {
     btn->setChecked(true);
   }
+}
+
+void MainWindow::onBookDetailsRequested(const QString &bookId) {
+  m_bookDetailsPanel->loadBook(bookId);
+  if (!m_bookDetailsPanel->isVisible()) {
+    m_bookDetailsPanel->show();
+    const int total = m_contentSplitter->width();
+    m_contentSplitter->setSizes({total / 2, total / 2});
+  }
+}
+
+void MainWindow::onBookDetailsDismissed() {
+  m_bookDetailsPanel->hide();
 }
 
 } // namespace bookhub::gui

--- a/src/gui/main_window.h
+++ b/src/gui/main_window.h
@@ -2,6 +2,7 @@
 
 #include <QMainWindow>
 
+class QSplitter;
 class QStackedWidget;
 class QButtonGroup;
 class QLabel;
@@ -10,11 +11,12 @@ class QThread;
 
 namespace bookhub::gui {
 
+class BookDetailsPanel;
+class ExploreScreen;
 class LibraryScreen;
 class LibraryService;
-class SearchScreen;
-class ExploreScreen;
 class QueryWorker;
+class SearchScreen;
 
 // ---------------------------------------------------------------------------
 // MainWindow — the top-level QMainWindow for BookHub.
@@ -42,6 +44,8 @@ public slots:
 private slots:
     void onNavTabChanged(int id, bool checked);
     void onLibraryExploreRequested();
+    void onBookDetailsRequested(const QString &bookId);
+    void onBookDetailsDismissed();
 
 private:
     friend class ::MainWindowTest;
@@ -54,12 +58,14 @@ private:
     QueryWorker    *m_queryWorker{};
     LibraryService *m_libraryService{};
 
-    QWidget        *m_navBar{};
-    QStackedWidget *m_stack{};
-    QButtonGroup   *m_navGroup{};
-    LibraryScreen  *m_libraryScreen{};
-    SearchScreen   *m_searchScreen{};
-    ExploreScreen  *m_exploreScreen{};
+    QWidget           *m_navBar{};
+    QSplitter         *m_contentSplitter{};
+    QStackedWidget    *m_stack{};
+    QButtonGroup      *m_navGroup{};
+    LibraryScreen     *m_libraryScreen{};
+    SearchScreen      *m_searchScreen{};
+    ExploreScreen     *m_exploreScreen{};
+    BookDetailsPanel  *m_bookDetailsPanel{};
 
     // Status bar widgets
     QLabel *m_statusLabel{};

--- a/src/gui/panels/book_details_panel.cpp
+++ b/src/gui/panels/book_details_panel.cpp
@@ -1,0 +1,575 @@
+#include "book_details_panel.h"
+
+#include "../services/book_details_service.h"
+#include "../services/library_service.h"
+#include "../style_tokens.h"
+
+#include <QComboBox>
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QSignalBlocker>
+#include <QStackedWidget>
+#include <QVBoxLayout>
+
+namespace bookhub::gui {
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+BookDetailsPanel::BookDetailsPanel(LibraryService *libraryService,
+                                   QueryWorker    *worker,
+                                   QWidget        *parent)
+    : QWidget(parent)
+    , m_libraryService(libraryService)
+{
+    m_detailsService = new BookDetailsService(this);
+    m_detailsService->connectToWorker(worker);
+
+    buildUi();
+
+    connect(m_detailsService, &BookDetailsService::detailsCompleted,
+            this, &BookDetailsPanel::onDetailsCompleted);
+    connect(m_detailsService, &BookDetailsService::formatsCompleted,
+            this, &BookDetailsPanel::onFormatsCompleted);
+    connect(m_libraryService, &LibraryService::addBookCompleted,
+            this, &BookDetailsPanel::onAddBookCompleted);
+    connect(m_libraryService, &LibraryService::removeBookCompleted,
+            this, &BookDetailsPanel::onRemoveBookCompleted);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+void BookDetailsPanel::loadBook(const QString &bookId)
+{
+    m_currentBookId = bookId;
+    m_outerStack->setCurrentIndex(0); // show loading before the request fires
+    m_pendingDetailsId = m_detailsService->requestBookDetails(bookId);
+}
+
+// ---------------------------------------------------------------------------
+// Private slots
+// ---------------------------------------------------------------------------
+
+void BookDetailsPanel::onDetailsCompleted(quint64 requestId, BookDetails details)
+{
+    if (requestId < m_pendingDetailsId)
+        return;
+
+    populateDetails(details);
+    m_outerStack->setCurrentIndex(1); // reveal content
+
+    if (!details.editions.isEmpty())
+        m_pendingFormatsId =
+            m_detailsService->requestFormatsForEdition(details.editions.first().editionId);
+    else
+        populateFormats({});
+}
+
+void BookDetailsPanel::onFormatsCompleted(quint64 requestId,
+                                          QList<BookFormatEntry> formats)
+{
+    if (requestId < m_pendingFormatsId)
+        return;
+    populateFormats(formats);
+}
+
+void BookDetailsPanel::onLanguageChanged(int index)
+{
+    if (index < 0 || index >= m_editionIds.size())
+        return;
+    m_pendingFormatsId =
+        m_detailsService->requestFormatsForEdition(m_editionIds.at(index));
+}
+
+void BookDetailsPanel::onAddToLibraryClicked()
+{
+    const int editionId = m_editionIds.value(m_langCombo->currentIndex(), 0);
+    m_libraryBtn->setEnabled(false);
+    m_pendingAddId = m_libraryService->requestAddBook(m_currentBookId, editionId);
+}
+
+void BookDetailsPanel::onRemoveFromLibraryClicked()
+{
+    m_libraryBtn->setEnabled(false);
+    m_pendingRemoveId = m_libraryService->requestRemoveBook(m_libraryItemId);
+}
+
+void BookDetailsPanel::onAddBookCompleted(quint64 requestId, QString /*bookId*/,
+                                          bool success, int newId)
+{
+    if (requestId < m_pendingAddId)
+        return;
+    if (success) {
+        m_inLibrary     = true;
+        m_libraryItemId = newId;
+    }
+    setLibraryButtonState(m_inLibrary);
+}
+
+void BookDetailsPanel::onRemoveBookCompleted(quint64 requestId, bool success)
+{
+    if (requestId < m_pendingRemoveId)
+        return;
+    if (success) {
+        m_inLibrary     = false;
+        m_libraryItemId = 0;
+    }
+    setLibraryButtonState(m_inLibrary);
+}
+
+void BookDetailsPanel::onToggleSummary()
+{
+    m_summaryExpanded = !m_summaryExpanded;
+    if (m_summaryExpanded) {
+        m_summaryLabel->setText(m_fullSummary);
+        m_showMoreBtn->setText(QStringLiteral("Show less"));
+    } else {
+        m_summaryLabel->setText(
+            m_fullSummary.left(kSummaryCollapseLen) + QStringLiteral("…"));
+        m_showMoreBtn->setText(QStringLiteral("Show more"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// UI construction
+// ---------------------------------------------------------------------------
+
+void BookDetailsPanel::buildUi()
+{
+    auto *root = new QVBoxLayout(this);
+    root->setContentsMargins(0, 0, 0, 0);
+    root->setSpacing(0);
+
+    // -----------------------------------------------------------------------
+    // Back button bar (40 px)
+    // -----------------------------------------------------------------------
+    auto *backBar = new QWidget(this);
+    backBar->setFixedHeight(40);
+    backBar->setObjectName(QStringLiteral("detailsBackBar"));
+    backBar->setStyleSheet(QStringLiteral(
+        "#detailsBackBar {"
+        "  background-color: %1;"
+        "  border-bottom: 1px solid %2;"
+        "}").arg(ColorBackground, ColorBorder));
+
+    auto *backLayout = new QHBoxLayout(backBar);
+    backLayout->setContentsMargins(SpacingSM, 0, SpacingSM, 0);
+    backLayout->setSpacing(0);
+
+    auto *backBtn = new QPushButton(QStringLiteral("← Back"), backBar);
+    backBtn->setFlat(true);
+    backBtn->setCursor(Qt::PointingHandCursor);
+    backBtn->setToolTip(QStringLiteral("Close book details"));
+    backBtn->setStyleSheet(QStringLiteral(
+        "QPushButton { color: %1; font-size: %2pt; border: none; background: transparent; }"
+        "QPushButton:hover { color: %3; }")
+        .arg(ColorAccent).arg(FontSizeBody).arg(ColorAccentHover));
+    connect(backBtn, &QPushButton::clicked, this, &BookDetailsPanel::dismissed);
+
+    backLayout->addWidget(backBtn);
+    backLayout->addStretch();
+    root->addWidget(backBar);
+
+    // -----------------------------------------------------------------------
+    // Outer stack: 0 = loading, 1 = content
+    // -----------------------------------------------------------------------
+    m_outerStack = new QStackedWidget(this);
+    root->addWidget(m_outerStack, 1);
+
+    // --- Loading page (index 0) ---
+    auto *loadingPage   = new QWidget(m_outerStack);
+    auto *loadingLayout = new QVBoxLayout(loadingPage);
+    auto *loadingLabel  = new QLabel(QStringLiteral("Loading…"), loadingPage);
+    loadingLabel->setAlignment(Qt::AlignCenter);
+    loadingLabel->setStyleSheet(QStringLiteral("color: %1; font-size: %2pt;")
+        .arg(ColorTextMuted).arg(FontSizeBody));
+    loadingLayout->addStretch();
+    loadingLayout->addWidget(loadingLabel, 0, Qt::AlignCenter);
+    loadingLayout->addStretch();
+    m_outerStack->addWidget(loadingPage); // index 0
+
+    // --- Content page (index 1) ---
+    auto *contentPage   = new QWidget(m_outerStack);
+    auto *contentLayout = new QVBoxLayout(contentPage);
+    contentLayout->setContentsMargins(0, 0, 0, 0);
+    contentLayout->setSpacing(0);
+
+    // Scroll area
+    auto *scrollArea = new QScrollArea(contentPage);
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->setFrameShape(QFrame::NoFrame);
+    scrollArea->setStyleSheet(QStringLiteral(
+        "QScrollArea { background: %1; border: none; }"
+        "QScrollArea > QWidget > QWidget { background: %1; }")
+        .arg(ColorSurface));
+
+    auto *inner = new QWidget(scrollArea);
+    inner->setObjectName(QStringLiteral("detailsInner"));
+    inner->setStyleSheet(QStringLiteral("#detailsInner { background: %1; }").arg(ColorSurface));
+
+    auto *innerLayout = new QVBoxLayout(inner);
+    innerLayout->setContentsMargins(SpacingLG, SpacingLG, SpacingLG, SpacingLG);
+    innerLayout->setSpacing(SpacingSM);
+
+    // Cover placeholder
+    auto *coverLabel = new QLabel(inner);
+    coverLabel->setFixedSize(200, 280);
+    coverLabel->setAlignment(Qt::AlignCenter);
+    coverLabel->setStyleSheet(QStringLiteral(
+        "QLabel {"
+        "  background-color: %1;"
+        "  border-radius: %2px;"
+        "  border: 1px solid %3;"
+        "  font-size: 48pt;"
+        "}").arg(ColorBackground).arg(RadiusMD).arg(ColorBorder));
+    coverLabel->setText(QStringLiteral("📖"));
+    innerLayout->addWidget(coverLabel, 0, Qt::AlignHCenter);
+    innerLayout->addSpacing(SpacingSM);
+
+    // Title
+    m_titleLabel = new QLabel(inner);
+    m_titleLabel->setWordWrap(true);
+    m_titleLabel->setStyleSheet(QStringLiteral(
+        "font-size: %1pt; font-weight: bold; color: %2;")
+        .arg(FontSizeTitle).arg(ColorTextPrimary));
+    innerLayout->addWidget(m_titleLabel);
+
+    // Author
+    m_authorLabel = new QLabel(inner);
+    m_authorLabel->setStyleSheet(QStringLiteral(
+        "font-size: %1pt; color: %2;")
+        .arg(FontSizeBody + 1).arg(ColorTextMuted));
+    innerLayout->addWidget(m_authorLabel);
+
+    // Meta: year + genres
+    m_metaLabel = new QLabel(inner);
+    m_metaLabel->setWordWrap(true);
+    m_metaLabel->setStyleSheet(QStringLiteral(
+        "font-size: %1pt; color: %2;")
+        .arg(FontSizeMeta).arg(ColorTextMuted));
+    innerLayout->addWidget(m_metaLabel);
+
+    // Separator
+    auto *sep1 = new QFrame(inner);
+    sep1->setFrameShape(QFrame::HLine);
+    sep1->setStyleSheet(QStringLiteral("color: %1;").arg(ColorBorder));
+    innerLayout->addWidget(sep1);
+
+    // Language section
+    auto *langRow    = new QWidget(inner);
+    auto *langLayout = new QHBoxLayout(langRow);
+    langLayout->setContentsMargins(0, 0, 0, 0);
+    langLayout->setSpacing(SpacingSM);
+
+    m_langLabel = new QLabel(QStringLiteral("Language:"), langRow);
+    m_langLabel->setStyleSheet(QStringLiteral(
+        "font-size: %1pt; font-weight: bold; color: %2;")
+        .arg(FontSizeBody).arg(ColorTextPrimary));
+    langLayout->addWidget(m_langLabel);
+
+    m_singleLangLabel = new QLabel(langRow);
+    m_singleLangLabel->setStyleSheet(QStringLiteral(
+        "font-size: %1pt; color: %2;"
+        "background: %3; border: 1px solid %4; border-radius: %5px; padding: 2px 8px;")
+        .arg(FontSizeBadge)
+        .arg(ColorLangBadgeText, ColorLangBadgeBg, ColorLangBadgeBorder)
+        .arg(RadiusPill));
+
+    m_langCombo = new QComboBox(langRow);
+    m_langCombo->setStyleSheet(QStringLiteral("font-size: %1pt;").arg(FontSizeBody));
+    connect(m_langCombo, &QComboBox::currentIndexChanged,
+            this, &BookDetailsPanel::onLanguageChanged);
+
+    langLayout->addWidget(m_singleLangLabel);
+    langLayout->addWidget(m_langCombo);
+    langLayout->addStretch();
+    innerLayout->addWidget(langRow);
+
+    // Separator
+    auto *sep2 = new QFrame(inner);
+    sep2->setFrameShape(QFrame::HLine);
+    sep2->setStyleSheet(QStringLiteral("color: %1;").arg(ColorBorder));
+    innerLayout->addWidget(sep2);
+
+    // Summary
+    auto *summaryHeader = new QLabel(QStringLiteral("Summary"), inner);
+    summaryHeader->setStyleSheet(QStringLiteral(
+        "font-size: %1pt; font-weight: bold; color: %2;")
+        .arg(FontSizeBody).arg(ColorTextPrimary));
+    innerLayout->addWidget(summaryHeader);
+
+    m_summaryLabel = new QLabel(inner);
+    m_summaryLabel->setWordWrap(true);
+    m_summaryLabel->setStyleSheet(QStringLiteral(
+        "font-size: %1pt; color: %2;")
+        .arg(FontSizeBody).arg(ColorTextPrimary));
+    innerLayout->addWidget(m_summaryLabel);
+
+    m_showMoreBtn = new QPushButton(QStringLiteral("Show more"), inner);
+    m_showMoreBtn->setFlat(true);
+    m_showMoreBtn->setCursor(Qt::PointingHandCursor);
+    m_showMoreBtn->setStyleSheet(QStringLiteral(
+        "QPushButton { color: %1; font-size: %2pt; border: none;"
+        "  text-align: left; padding: 0; background: transparent; }"
+        "QPushButton:hover { color: %3; }")
+        .arg(ColorAccent).arg(FontSizeBody).arg(ColorAccentHover));
+    m_showMoreBtn->setVisible(false);
+    connect(m_showMoreBtn, &QPushButton::clicked,
+            this, &BookDetailsPanel::onToggleSummary);
+    innerLayout->addWidget(m_showMoreBtn);
+
+    // Separator
+    auto *sep3 = new QFrame(inner);
+    sep3->setFrameShape(QFrame::HLine);
+    sep3->setStyleSheet(QStringLiteral("color: %1;").arg(ColorBorder));
+    innerLayout->addWidget(sep3);
+
+    // Formats section
+    auto *formatsHeader = new QLabel(QStringLiteral("Available formats"), inner);
+    formatsHeader->setStyleSheet(QStringLiteral(
+        "font-size: %1pt; font-weight: bold; color: %2;")
+        .arg(FontSizeBody).arg(ColorTextPrimary));
+    innerLayout->addWidget(formatsHeader);
+
+    m_formatsWidget = new QWidget(inner);
+    m_formatsLayout = new QVBoxLayout(m_formatsWidget);
+    m_formatsLayout->setContentsMargins(0, 0, 0, 0);
+    m_formatsLayout->setSpacing(SpacingXS);
+    innerLayout->addWidget(m_formatsWidget);
+
+    innerLayout->addStretch();
+    scrollArea->setWidget(inner);
+    contentLayout->addWidget(scrollArea, 1);
+
+    // -----------------------------------------------------------------------
+    // Action bar (pinned below scroll, always visible)
+    // -----------------------------------------------------------------------
+    auto *actionBar = new QWidget(contentPage);
+    actionBar->setObjectName(QStringLiteral("detailsActionBar"));
+    actionBar->setStyleSheet(QStringLiteral(
+        "#detailsActionBar {"
+        "  background-color: %1;"
+        "  border-top: 1px solid %2;"
+        "}").arg(ColorSurface, ColorBorder));
+
+    auto *actionLayout = new QVBoxLayout(actionBar);
+    actionLayout->setContentsMargins(SpacingMD, SpacingSM, SpacingMD, SpacingSM);
+    actionLayout->setSpacing(SpacingSM);
+
+    m_libraryBtn = new QPushButton(actionBar);
+    m_libraryBtn->setFixedHeight(40);
+    m_libraryBtn->setCursor(Qt::PointingHandCursor);
+    connect(m_libraryBtn, &QPushButton::clicked, this, [this] {
+        if (m_inLibrary)
+            onRemoveFromLibraryClicked();
+        else
+            onAddToLibraryClicked();
+    });
+    actionLayout->addWidget(m_libraryBtn);
+    setLibraryButtonState(false); // sets initial style + text
+
+    auto *secondaryRow    = new QWidget(actionBar);
+    auto *secondaryLayout = new QHBoxLayout(secondaryRow);
+    secondaryLayout->setContentsMargins(0, 0, 0, 0);
+    secondaryLayout->setSpacing(SpacingSM);
+
+    const QString secondaryStyle = QStringLiteral(
+        "QPushButton {"
+        "  border: 1px solid %1; border-radius: %2px;"
+        "  font-size: %3pt; color: %4; background: transparent; padding: 8px;"
+        "}"
+        "QPushButton:hover { background: %5; }"
+        "QPushButton:disabled { color: %6; border-color: %6; }")
+        .arg(ColorBorder).arg(RadiusMD).arg(FontSizeBody)
+        .arg(ColorTextPrimary, ColorBackground, ColorTextMuted);
+
+    m_downloadBtn = new QPushButton(QStringLiteral("↓ Download"), secondaryRow);
+    m_downloadBtn->setStyleSheet(secondaryStyle);
+    m_downloadBtn->setToolTip(QStringLiteral("Download — coming soon"));
+    m_downloadBtn->setEnabled(false); // Task 11
+    connect(m_downloadBtn, &QPushButton::clicked, this,
+            [this] { emit downloadRequested(m_currentBookId); });
+    secondaryLayout->addWidget(m_downloadBtn);
+
+    m_audiobookBtn = new QPushButton(QStringLiteral("♪ Audiobook"), secondaryRow);
+    m_audiobookBtn->setStyleSheet(secondaryStyle);
+    m_audiobookBtn->setToolTip(QStringLiteral("Audiobook conversion — coming soon"));
+    m_audiobookBtn->setEnabled(false); // Task 12
+    connect(m_audiobookBtn, &QPushButton::clicked, this,
+            [this] { emit audiobookRequested(m_currentBookId); });
+    secondaryLayout->addWidget(m_audiobookBtn);
+
+    actionLayout->addWidget(secondaryRow);
+    contentLayout->addWidget(actionBar);
+
+    m_outerStack->addWidget(contentPage); // index 1
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+void BookDetailsPanel::populateDetails(const BookDetails &details)
+{
+    m_inLibrary     = details.inLibrary;
+    m_libraryItemId = details.libraryItemId;
+
+    m_titleLabel->setText(details.title.isEmpty()
+        ? QStringLiteral("Unknown Title") : details.title);
+    m_authorLabel->setText(details.author.isEmpty()
+        ? QStringLiteral("Unknown Author") : details.author);
+
+    QStringList metaParts;
+    if (details.publishYear > 0)
+        metaParts << QString::number(details.publishYear);
+    if (!details.genres.isEmpty())
+        metaParts << details.genres.join(QStringLiteral(", "));
+    m_metaLabel->setText(metaParts.join(QStringLiteral("  •  ")));
+    m_metaLabel->setVisible(!metaParts.isEmpty());
+
+    // Populate edition IDs before populating combo (avoids stale index in
+    // onLanguageChanged which fires when the combo transitions from empty to
+    // the first item).
+    m_editionIds.clear();
+    for (const auto &ed : details.editions)
+        m_editionIds.append(ed.editionId);
+
+    {
+        QSignalBlocker blocker(m_langCombo);
+        m_langCombo->clear();
+        for (const auto &ed : details.editions)
+            m_langCombo->addItem(ed.language);
+    }
+
+    const int edCount   = details.editions.size();
+    const bool multiLang = edCount > 1;
+    m_langCombo->setVisible(multiLang);
+    m_singleLangLabel->setVisible(!multiLang && edCount == 1);
+    m_langLabel->setVisible(edCount > 0);
+    if (!multiLang && edCount == 1)
+        m_singleLangLabel->setText(details.editions.first().language);
+
+    // Summary
+    m_fullSummary    = details.summary.isEmpty()
+        ? QStringLiteral("No summary available for this edition.")
+        : details.summary;
+    m_summaryExpanded = false;
+
+    if (m_fullSummary.length() > kSummaryCollapseLen) {
+        m_summaryLabel->setText(
+            m_fullSummary.left(kSummaryCollapseLen) + QStringLiteral("…"));
+        m_showMoreBtn->setText(QStringLiteral("Show more"));
+        m_showMoreBtn->setVisible(true);
+    } else {
+        m_summaryLabel->setText(m_fullSummary);
+        m_showMoreBtn->setVisible(false);
+    }
+
+    setLibraryButtonState(m_inLibrary);
+
+    // Clear formats; they'll be loaded by the requestFormatsForEdition call
+    // that follows immediately in onDetailsCompleted.
+    clearFormatsSection();
+    auto *placeholder = new QLabel(QStringLiteral("Loading formats…"),
+                                   m_formatsWidget);
+    placeholder->setStyleSheet(QStringLiteral("color: %1; font-size: %2pt;")
+        .arg(ColorTextMuted).arg(FontSizeBody));
+    m_formatsLayout->addWidget(placeholder);
+}
+
+void BookDetailsPanel::populateFormats(const QList<BookFormatEntry> &formats)
+{
+    clearFormatsSection();
+
+    if (formats.isEmpty()) {
+        auto *noFmt = new QLabel(
+            QStringLiteral("No downloadable formats available yet."),
+            m_formatsWidget);
+        noFmt->setWordWrap(true);
+        noFmt->setStyleSheet(QStringLiteral("color: %1; font-size: %2pt;")
+            .arg(ColorTextMuted).arg(FontSizeBody));
+        m_formatsLayout->addWidget(noFmt);
+        return;
+    }
+
+    for (const auto &fmt : formats) {
+        auto *row       = new QWidget(m_formatsWidget);
+        auto *rowLayout = new QHBoxLayout(row);
+        rowLayout->setContentsMargins(0, SpacingXS, 0, SpacingXS);
+        rowLayout->setSpacing(SpacingSM);
+
+        auto *fmtLabel = new QLabel(fmt.formatType, row);
+        fmtLabel->setFixedWidth(36);
+        fmtLabel->setStyleSheet(QStringLiteral(
+            "font-size: %1pt; font-weight: bold; color: %2;")
+            .arg(FontSizeBody).arg(ColorTextPrimary));
+        rowLayout->addWidget(fmtLabel);
+
+        for (const auto &src : fmt.sources) {
+            auto *srcBtn = new QPushButton(
+                QStringLiteral("[%1]").arg(src.sourceName), row);
+            srcBtn->setToolTip(src.downloadLink);
+            srcBtn->setCursor(Qt::PointingHandCursor);
+            srcBtn->setStyleSheet(QStringLiteral(
+                "QPushButton {"
+                "  color: %1; background: %2; border: 1px solid %3;"
+                "  border-radius: %4px; padding: 2px 8px; font-size: %5pt;"
+                "}"
+                "QPushButton:hover { background: %6; }")
+                .arg(ColorSrcBadgeText, ColorSrcBadgeBg, ColorSrcBadgeBorder)
+                .arg(RadiusPill).arg(FontSizeBadge)
+                .arg(ColorLangBadgeBg));
+            rowLayout->addWidget(srcBtn);
+        }
+
+        rowLayout->addStretch();
+        m_formatsLayout->addWidget(row);
+    }
+}
+
+void BookDetailsPanel::setLibraryButtonState(bool inLibrary)
+{
+    if (inLibrary) {
+        m_libraryBtn->setText(QStringLiteral("✓ In Library  (click to remove)"));
+        m_libraryBtn->setToolTip(QStringLiteral("Remove from library"));
+        m_libraryBtn->setStyleSheet(QStringLiteral(
+            "QPushButton {"
+            "  background-color: %1; color: white;"
+            "  border-radius: %2px; font-size: %3pt; border: none;"
+            "}"
+            "QPushButton:hover { background-color: #15803D; }"
+            "QPushButton:disabled { background-color: %4; color: %5; }")
+            .arg(ColorSuccess).arg(RadiusMD).arg(FontSizeBody)
+            .arg(ColorBorder, ColorTextMuted));
+    } else {
+        m_libraryBtn->setText(QStringLiteral("＋ Add to Library"));
+        m_libraryBtn->setToolTip(QStringLiteral("Add to library"));
+        m_libraryBtn->setStyleSheet(QStringLiteral(
+            "QPushButton {"
+            "  background-color: %1; color: white;"
+            "  border-radius: %2px; font-size: %3pt; border: none;"
+            "}"
+            "QPushButton:hover { background-color: %4; }"
+            "QPushButton:disabled { background-color: %5; color: %6; }")
+            .arg(ColorAccent).arg(RadiusMD).arg(FontSizeBody)
+            .arg(ColorAccentHover, ColorBorder, ColorTextMuted));
+    }
+    m_libraryBtn->setEnabled(true);
+}
+
+void BookDetailsPanel::clearFormatsSection()
+{
+    while (QLayoutItem *item = m_formatsLayout->takeAt(0)) {
+        delete item->widget();
+        delete item;
+    }
+}
+
+} // namespace bookhub::gui

--- a/src/gui/panels/book_details_panel.cpp
+++ b/src/gui/panels/book_details_panel.cpp
@@ -49,7 +49,8 @@ void BookDetailsPanel::loadBook(const QString &bookId)
 {
     m_currentBookId = bookId;
     m_outerStack->setCurrentIndex(0); // show loading before the request fires
-    m_pendingDetailsId = m_detailsService->requestBookDetails(bookId);
+    m_pendingDetailsId = m_detailsService->peekNextId();
+    m_detailsService->requestBookDetails(bookId);
 }
 
 // ---------------------------------------------------------------------------
@@ -58,23 +59,24 @@ void BookDetailsPanel::loadBook(const QString &bookId)
 
 void BookDetailsPanel::onDetailsCompleted(quint64 requestId, BookDetails details)
 {
-    if (requestId < m_pendingDetailsId)
+    if (requestId != m_pendingDetailsId)
         return;
 
     populateDetails(details);
     m_outerStack->setCurrentIndex(1); // reveal content
 
-    if (!details.editions.isEmpty())
-        m_pendingFormatsId =
-            m_detailsService->requestFormatsForEdition(details.editions.first().editionId);
-    else
+    if (!details.editions.isEmpty()) {
+        m_pendingFormatsId = m_detailsService->peekNextId();
+        m_detailsService->requestFormatsForEdition(details.editions.first().editionId);
+    } else {
         populateFormats({});
+    }
 }
 
 void BookDetailsPanel::onFormatsCompleted(quint64 requestId,
                                           QList<BookFormatEntry> formats)
 {
-    if (requestId < m_pendingFormatsId)
+    if (requestId != m_pendingFormatsId)
         return;
     populateFormats(formats);
 }
@@ -83,28 +85,31 @@ void BookDetailsPanel::onLanguageChanged(int index)
 {
     if (index < 0 || index >= m_editionIds.size())
         return;
-    m_pendingFormatsId =
-        m_detailsService->requestFormatsForEdition(m_editionIds.at(index));
+    m_pendingFormatsId = m_detailsService->peekNextId();
+    m_detailsService->requestFormatsForEdition(m_editionIds.at(index));
 }
 
 void BookDetailsPanel::onAddToLibraryClicked()
 {
     const int editionId = m_editionIds.value(m_langCombo->currentIndex(), 0);
     m_libraryBtn->setEnabled(false);
-    m_pendingAddId = m_libraryService->requestAddBook(m_currentBookId, editionId);
+    m_pendingAddId = m_libraryService->peekNextId();
+    m_libraryService->requestAddBook(m_currentBookId, editionId);
 }
 
 void BookDetailsPanel::onRemoveFromLibraryClicked()
 {
     m_libraryBtn->setEnabled(false);
-    m_pendingRemoveId = m_libraryService->requestRemoveBook(m_libraryItemId);
+    m_pendingRemoveId = m_libraryService->peekNextId();
+    m_libraryService->requestRemoveBook(m_libraryItemId);
 }
 
 void BookDetailsPanel::onAddBookCompleted(quint64 requestId, QString /*bookId*/,
                                           bool success, int newId)
 {
-    if (requestId < m_pendingAddId)
+    if (requestId != m_pendingAddId)
         return;
+    m_pendingAddId = 0;
     if (success) {
         m_inLibrary     = true;
         m_libraryItemId = newId;
@@ -114,8 +119,9 @@ void BookDetailsPanel::onAddBookCompleted(quint64 requestId, QString /*bookId*/,
 
 void BookDetailsPanel::onRemoveBookCompleted(quint64 requestId, bool success)
 {
-    if (requestId < m_pendingRemoveId)
+    if (requestId != m_pendingRemoveId)
         return;
+    m_pendingRemoveId = 0;
     if (success) {
         m_inLibrary     = false;
         m_libraryItemId = 0;
@@ -525,7 +531,7 @@ void BookDetailsPanel::populateFormats(const QList<BookFormatEntry> &formats)
                 "QPushButton:hover { background: %6; }")
                 .arg(ColorSrcBadgeText, ColorSrcBadgeBg, ColorSrcBadgeBorder)
                 .arg(RadiusPill).arg(FontSizeBadge)
-                .arg(ColorLangBadgeBg));
+                .arg(ColorSrcBadgeHover));
             rowLayout->addWidget(srcBtn);
         }
 

--- a/src/gui/panels/book_details_panel.h
+++ b/src/gui/panels/book_details_panel.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "../services/book_details_service.h"
+
+#include <QWidget>
+#include <QList>
+
+class QComboBox;
+class QLabel;
+class QPushButton;
+class QScrollArea;
+class QStackedWidget;
+class QVBoxLayout;
+class BookDetailsPanelTest; // test friend — defined in tests/gui/
+
+namespace bookhub::gui {
+
+class LibraryService;
+class QueryWorker;
+
+// ---------------------------------------------------------------------------
+// BookDetailsPanel — right pane of the content-area QSplitter (spec §5).
+//
+// Lifecycle:
+//   • Created once in MainWindow; sits as the right child of m_contentSplitter.
+//   • Hidden initially (splitter gives all space to the screen stack).
+//   • Call loadBook(bookId) to start loading; the panel switches to a loading
+//     state, then to full content once queries complete.
+//   • Connect dismissed() to MainWindow::onBookDetailsDismissed() so clicking
+//     "← Back" collapses the panel.
+//
+// Library mutations (add/remove) go through the shared LibraryService so that
+// LibraryScreen automatically refreshes via libraryChanged().
+// ---------------------------------------------------------------------------
+
+class BookDetailsPanel : public QWidget {
+    Q_OBJECT
+public:
+    explicit BookDetailsPanel(LibraryService *libraryService,
+                              QueryWorker    *worker,
+                              QWidget        *parent = nullptr);
+
+    void loadBook(const QString &bookId);
+
+signals:
+    void dismissed();
+    void downloadRequested(const QString &bookId);
+    void audiobookRequested(const QString &bookId);
+
+private slots:
+    void onDetailsCompleted(quint64 requestId, bookhub::gui::BookDetails details);
+    void onFormatsCompleted(quint64 requestId,
+                            QList<bookhub::gui::BookFormatEntry> formats);
+    void onLanguageChanged(int index);
+    void onAddToLibraryClicked();
+    void onRemoveFromLibraryClicked();
+    void onAddBookCompleted(quint64 requestId, QString bookId, bool success, int newId);
+    void onRemoveBookCompleted(quint64 requestId, bool success);
+    void onToggleSummary();
+
+private:
+    void buildUi();
+    void populateDetails(const BookDetails &details);
+    void populateFormats(const QList<BookFormatEntry> &formats);
+    void setLibraryButtonState(bool inLibrary);
+    void clearFormatsSection();
+
+    friend class ::BookDetailsPanelTest;
+
+    // Services (not owned — both outlive this panel)
+    BookDetailsService *m_detailsService{};
+    LibraryService     *m_libraryService{};
+
+    // Panel state
+    QString    m_currentBookId;
+    bool       m_inLibrary{false};
+    int        m_libraryItemId{0};
+    QString    m_fullSummary;
+    bool       m_summaryExpanded{false};
+    QList<int> m_editionIds;   // parallel to m_langCombo items
+
+    // Pending request IDs for stale-response suppression
+    quint64 m_pendingDetailsId{0};
+    quint64 m_pendingFormatsId{0};
+    quint64 m_pendingAddId{0};
+    quint64 m_pendingRemoveId{0};
+
+    // Outer stack: 0 = loading, 1 = content
+    QStackedWidget *m_outerStack{};
+
+    // Metadata widgets (inside scroll area)
+    QLabel      *m_titleLabel{};
+    QLabel      *m_authorLabel{};
+    QLabel      *m_metaLabel{};
+    QLabel      *m_langLabel{};
+    QComboBox   *m_langCombo{};
+    QLabel      *m_singleLangLabel{};
+    QLabel      *m_summaryLabel{};
+    QPushButton *m_showMoreBtn{};
+    QWidget     *m_formatsWidget{};
+    QVBoxLayout *m_formatsLayout{};
+
+    // Action bar (pinned below scroll area)
+    QPushButton *m_libraryBtn{};
+    QPushButton *m_downloadBtn{};
+    QPushButton *m_audiobookBtn{};
+
+    static constexpr int kSummaryCollapseLen = 320;
+};
+
+} // namespace bookhub::gui

--- a/src/gui/query_worker.cpp
+++ b/src/gui/query_worker.cpp
@@ -1,8 +1,9 @@
 #include "query_worker.h"
 
-#include "services/search_service.h"
-#include "services/library_service.h"
+#include "services/book_details_service.h"
 #include "services/explore_service.h"
+#include "services/library_service.h"
+#include "services/search_service.h"
 
 #include <QSqlDatabase>
 #include <QSqlError>
@@ -128,6 +129,22 @@ void QueryWorker::handleBooksForGenreRequest(quint64 requestId, QString genre,
 {
     emit booksForGenreCompleted(requestId,
         internal::fetchBooksForGenre(genre, offset, limit, conn()));
+}
+
+// ---------------------------------------------------------------------------
+// Book details handlers
+// ---------------------------------------------------------------------------
+
+void QueryWorker::handleBookDetailsRequest(quint64 requestId, QString bookId)
+{
+    emit bookDetailsCompleted(requestId,
+        internal::fetchBookDetails(bookId, conn()));
+}
+
+void QueryWorker::handleFormatsForEditionRequest(quint64 requestId, int editionId)
+{
+    emit formatsForEditionCompleted(requestId,
+        internal::fetchFormatsForEdition(editionId, conn()));
 }
 
 } // namespace bookhub::gui

--- a/src/gui/query_worker.h
+++ b/src/gui/query_worker.h
@@ -5,9 +5,10 @@
 #include <QString>
 #include <QStringList>
 
-#include "services/search_service.h"
-#include "services/library_service.h"
+#include "services/book_details_service.h"
 #include "services/explore_service.h"
+#include "services/library_service.h"
+#include "services/search_service.h"
 
 namespace bookhub::gui {
 
@@ -51,6 +52,10 @@ public slots:
     virtual void handleCategoriesRequest(quint64 requestId);
     virtual void handleBooksForGenreRequest(quint64 requestId, QString genre, int offset, int limit);
 
+    // Book details
+    virtual void handleBookDetailsRequest(quint64 requestId, QString bookId);
+    virtual void handleFormatsForEditionRequest(quint64 requestId, int editionId);
+
 signals:
     // Search results
     void searchCompleted(quint64 requestId, QList<bookhub::gui::SearchResult> results);
@@ -70,6 +75,11 @@ signals:
     void newArrivalsCompleted(quint64 requestId, QList<bookhub::gui::ExploreBook> books);
     void categoriesCompleted(quint64 requestId, QList<bookhub::gui::ExploreCategory> categories);
     void booksForGenreCompleted(quint64 requestId, QList<bookhub::gui::ExploreBook> books);
+
+    // Book details results
+    void bookDetailsCompleted(quint64 requestId, bookhub::gui::BookDetails details);
+    void formatsForEditionCompleted(quint64 requestId,
+                                    QList<bookhub::gui::BookFormatEntry> formats);
 
 private:
     static constexpr const char *kConnectionName = "gui_query_connection";

--- a/src/gui/services/book_details_service.cpp
+++ b/src/gui/services/book_details_service.cpp
@@ -1,0 +1,163 @@
+#include "book_details_service.h"
+#include "../query_worker.h"
+
+#include <QMap>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QDebug>
+
+namespace bookhub::gui {
+
+BookDetailsService::BookDetailsService(QObject *parent)
+    : QObject(parent)
+{}
+
+void BookDetailsService::connectToWorker(QueryWorker *worker)
+{
+    connect(this, &BookDetailsService::bookDetailsRequested,
+            worker, &QueryWorker::handleBookDetailsRequest);
+    connect(this, &BookDetailsService::formatsForEditionRequested,
+            worker, &QueryWorker::handleFormatsForEditionRequest);
+
+    connect(worker, &QueryWorker::bookDetailsCompleted, this,
+            [this](quint64 id, BookDetails details) {
+                emit detailsCompleted(id, details);
+            });
+    connect(worker, &QueryWorker::formatsForEditionCompleted, this,
+            [this](quint64 id, QList<BookFormatEntry> formats) {
+                emit formatsCompleted(id, formats);
+            });
+}
+
+quint64 BookDetailsService::requestBookDetails(const QString &bookId)
+{
+    const quint64 id = m_nextRequestId++;
+    emit bookDetailsRequested(id, bookId);
+    return id;
+}
+
+quint64 BookDetailsService::requestFormatsForEdition(int editionId)
+{
+    const quint64 id = m_nextRequestId++;
+    emit formatsForEditionRequested(id, editionId);
+    return id;
+}
+
+// ---------------------------------------------------------------------------
+// Internal free functions
+// ---------------------------------------------------------------------------
+
+namespace internal {
+
+BookDetails fetchBookDetails(const QString &bookId, const QString &connectionName)
+{
+    BookDetails result;
+    result.bookId = bookId;
+
+    // Core book data + library status + genres (one aggregating query)
+    const QString coreSql = QStringLiteral(R"(
+        SELECT
+            b.title,
+            b.author,
+            COALESCE(b.publish_year, 0)                       AS publish_year,
+            COALESCE(b.summary, '')                           AS summary,
+            COALESCE(GROUP_CONCAT(DISTINCT g.genre_name), '') AS genres,
+            COALESCE(li.id, 0)                                AS library_item_id
+        FROM books b
+        LEFT JOIN book_genres    bg ON bg.book_id = b.book_id
+        LEFT JOIN genres          g ON g.id        = bg.genre_id
+        LEFT JOIN library_items  li ON li.book_id  = b.book_id
+        WHERE b.book_id = ?
+        GROUP BY b.book_id, li.id
+    )");
+
+    QSqlQuery coreQ(QSqlDatabase::database(connectionName));
+    coreQ.prepare(coreSql);
+    coreQ.addBindValue(bookId);
+
+    if (!coreQ.exec() || !coreQ.next()) {
+        qWarning() << "internal::fetchBookDetails (core) failed:"
+                   << coreQ.lastError().text();
+        return result;
+    }
+
+    result.title         = coreQ.value(0).toString();
+    result.author        = coreQ.value(1).toString();
+    result.publishYear   = coreQ.value(2).toInt();
+    result.summary       = coreQ.value(3).toString();
+    result.libraryItemId = coreQ.value(5).toInt();
+    result.inLibrary     = result.libraryItemId > 0;
+
+    const QString genreStr = coreQ.value(4).toString();
+    if (!genreStr.isEmpty())
+        result.genres = genreStr.split(QLatin1Char(','));
+
+    // Editions (language list for selector)
+    QSqlQuery edQ(QSqlDatabase::database(connectionName));
+    edQ.prepare(QStringLiteral(
+        "SELECT id, language FROM editions WHERE book_id = ? ORDER BY language"));
+    edQ.addBindValue(bookId);
+
+    if (!edQ.exec()) {
+        qWarning() << "internal::fetchBookDetails (editions) failed:"
+                   << edQ.lastError().text();
+        return result;
+    }
+
+    while (edQ.next()) {
+        BookEditionEntry ed;
+        ed.editionId = edQ.value(0).toInt();
+        ed.language  = edQ.value(1).toString();
+        result.editions.append(ed);
+    }
+
+    return result;
+}
+
+QList<BookFormatEntry> fetchFormatsForEdition(int editionId,
+                                               const QString &connectionName)
+{
+    const QString sql = QStringLiteral(R"(
+        SELECT f.format_type, s.source_name, s.download_link
+        FROM   formats f
+        JOIN   sources s ON s.format_id = f.id
+        WHERE  f.edition_id = ?
+        ORDER  BY f.format_type, s.source_name
+    )");
+
+    QSqlQuery query(QSqlDatabase::database(connectionName));
+    query.prepare(sql);
+    query.addBindValue(editionId);
+
+    if (!query.exec()) {
+        qWarning() << "internal::fetchFormatsForEdition failed:"
+                   << query.lastError().text();
+        return {};
+    }
+
+    QMap<QString, int> fmtIndex;
+    QList<BookFormatEntry> formats;
+
+    while (query.next()) {
+        const QString fmt = query.value(0).toString();
+
+        if (!fmtIndex.contains(fmt)) {
+            BookFormatEntry entry;
+            entry.formatType = fmt;
+            formats.append(entry);
+            fmtIndex[fmt] = static_cast<int>(formats.size()) - 1;
+        }
+
+        BookSourceEntry src;
+        src.sourceName   = query.value(1).toString();
+        src.downloadLink = query.value(2).toString();
+        formats[fmtIndex[fmt]].sources.append(src);
+    }
+
+    return formats;
+}
+
+} // namespace internal
+
+} // namespace bookhub::gui

--- a/src/gui/services/book_details_service.h
+++ b/src/gui/services/book_details_service.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QList>
+
+namespace bookhub::gui {
+
+struct BookSourceEntry {
+    QString sourceName;
+    QString downloadLink;
+};
+
+struct BookFormatEntry {
+    QString                formatType;
+    QList<BookSourceEntry> sources;
+};
+
+struct BookEditionEntry {
+    int     editionId{};
+    QString language;
+};
+
+struct BookDetails {
+    QString                 bookId;
+    QString                 title;
+    QString                 author;
+    int                     publishYear{0};
+    QString                 summary;
+    QStringList             genres;
+    QList<BookEditionEntry> editions;
+    bool                    inLibrary{false};
+    int                     libraryItemId{0};
+};
+
+class QueryWorker;
+
+// ---------------------------------------------------------------------------
+// BookDetailsService — async facade for loading a single book's full details.
+//
+// Two-step loading pattern:
+//   1. requestBookDetails(bookId) → detailsCompleted — carries core metadata,
+//      all editions (for the language selector), and current library status.
+//   2. requestFormatsForEdition(editionId) → formatsCompleted — called once on
+//      initial load and again whenever the user switches language editions.
+// ---------------------------------------------------------------------------
+
+class BookDetailsService : public QObject {
+    Q_OBJECT
+public:
+    explicit BookDetailsService(QObject *parent = nullptr);
+
+    void connectToWorker(QueryWorker *worker);
+
+    quint64 requestBookDetails(const QString &bookId);
+    quint64 requestFormatsForEdition(int editionId);
+
+signals:
+    // Result signals — delivered on the GUI thread
+    void detailsCompleted(quint64 requestId, bookhub::gui::BookDetails details);
+    void formatsCompleted(quint64 requestId, QList<bookhub::gui::BookFormatEntry> formats);
+
+    // Internal request signals — routed to QueryWorker
+    void bookDetailsRequested(quint64 requestId, QString bookId);
+    void formatsForEditionRequested(quint64 requestId, int editionId);
+
+private:
+    quint64 m_nextRequestId{1};
+};
+
+// ---------------------------------------------------------------------------
+// Internal free functions — called by QueryWorker slots and integration tests.
+// Each takes an explicit connectionName so they work on any SQL connection.
+// ---------------------------------------------------------------------------
+namespace internal {
+    BookDetails            fetchBookDetails(const QString &bookId,
+                                           const QString &connectionName);
+    QList<BookFormatEntry> fetchFormatsForEdition(int editionId,
+                                                   const QString &connectionName);
+} // namespace internal
+
+} // namespace bookhub::gui

--- a/src/gui/services/book_details_service.h
+++ b/src/gui/services/book_details_service.h
@@ -53,6 +53,9 @@ public:
 
     void connectToWorker(QueryWorker *worker);
 
+    // Call before request*() to capture the pending ID before synchronous dispatch.
+    quint64 peekNextId() const { return m_nextRequestId; }
+
     quint64 requestBookDetails(const QString &bookId);
     quint64 requestFormatsForEdition(int editionId);
 

--- a/src/gui/services/library_service.h
+++ b/src/gui/services/library_service.h
@@ -39,6 +39,9 @@ public:
     void connectToWorker(QueryWorker *worker);
     bool isBusy() const;
 
+    // Call before request*() to capture the pending ID before synchronous dispatch.
+    quint64 peekNextId() const { return m_nextRequestId.load(std::memory_order_relaxed); }
+
     quint64 requestFetchItems(const QString &sortColumn = QStringLiteral("added_date"));
     quint64 requestAddBook(const QString &bookId, int editionId);
     quint64 requestRemoveBook(int libraryItemId);

--- a/src/gui/style_tokens.h
+++ b/src/gui/style_tokens.h
@@ -33,6 +33,7 @@ inline constexpr const char* ColorLangBadgeText = "#1D4ED8";
 inline constexpr const char* ColorLangBadgeBorder= "#BFDBFE";
 
 inline constexpr const char* ColorSrcBadgeBg    = "#F0FDF4";
+inline constexpr const char* ColorSrcBadgeHover = "#DCFCE7";
 inline constexpr const char* ColorSrcBadgeText  = "#15803D";
 inline constexpr const char* ColorSrcBadgeBorder= "#BBF7D0";
 

--- a/tests/gui/test_book_details_panel.cpp
+++ b/tests/gui/test_book_details_panel.cpp
@@ -285,13 +285,12 @@ void BookDetailsPanelTest::dismissButton_emitsDismissedSignal()
     BookDetailsPanel panel(m_libraryService, m_worker);
     QSignalSpy spy(&panel, &BookDetailsPanel::dismissed);
 
-    // find the button with "Back" text
-    auto it = std::find_if(panel.findChildren<QPushButton *>().begin(),
-                           panel.findChildren<QPushButton *>().end(),
+    const auto buttons = panel.findChildren<QPushButton *>();
+    auto it = std::find_if(buttons.begin(), buttons.end(),
                            [](QPushButton *b) {
                                return b->text().contains(QStringLiteral("Back"));
                            });
-    QVERIFY(it != panel.findChildren<QPushButton *>().end());
+    QVERIFY(it != buttons.end());
     (*it)->click();
 
     QCOMPARE(spy.count(), 1);

--- a/tests/gui/test_book_details_panel.cpp
+++ b/tests/gui/test_book_details_panel.cpp
@@ -285,7 +285,6 @@ void BookDetailsPanelTest::dismissButton_emitsDismissedSignal()
     BookDetailsPanel panel(m_libraryService, m_worker);
     QSignalSpy spy(&panel, &BookDetailsPanel::dismissed);
 
-    auto *backBtn = panel.findChildren<QPushButton *>().first();
     // find the button with "Back" text
     auto it = std::find_if(panel.findChildren<QPushButton *>().begin(),
                            panel.findChildren<QPushButton *>().end(),

--- a/tests/gui/test_book_details_panel.cpp
+++ b/tests/gui/test_book_details_panel.cpp
@@ -1,0 +1,363 @@
+#include <QComboBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QSignalSpy>
+#include <QStackedWidget>
+
+#include "gui/panels/book_details_panel.h"
+#include "gui/services/library_service.h"
+
+#include "support/test_database_utils.h"
+#include "support/test_query_worker.h"
+
+#include <QtTest>
+#include <memory>
+
+using namespace bookhub::gui;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static bool execSql(const QSqlDatabase &db, const QString &sql)
+{
+    return bookhub::tests::execSql(db, sql);
+}
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+
+class BookDetailsPanelTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+
+    void loadBook_populatesMetadata();
+    void loadBook_showsLoadingThenContent();
+    void loadBook_notInLibrary_showsAddButton();
+    void loadBook_inLibrary_showsInLibraryButton();
+    void loadBook_multipleEditions_showsComboBox();
+    void loadBook_singleEdition_showsSingleLabel();
+    void loadBook_longSummary_showsShowMoreButton();
+    void loadBook_shortSummary_hidesShowMoreButton();
+    void loadBook_populatesFormats();
+    void addToLibrary_updatesButtonToInLibrary();
+    void removeFromLibrary_updatesButtonToAdd();
+    void dismissButton_emitsDismissedSignal();
+    void languageChange_requestsFormatsForNewEdition();
+    void showMore_expandsAndCollapsesSummary();
+
+private:
+    // Insert a minimal book + edition + format + source. Returns editionId.
+    int insertBook(const QString &bookId, const QString &title = QStringLiteral("Test Title"),
+                   const QString &author = QStringLiteral("Test Author"),
+                   const QString &language = QStringLiteral("en"))
+    {
+        const auto &db = m_db->database();
+        execSql(db, QStringLiteral(
+            "INSERT INTO books (book_id, title, author, publish_year, summary) "
+            "VALUES ('%1', '%2', '%3', 1900, 'A short summary.')")
+            .arg(bookId, title, author));
+        execSql(db, QStringLiteral(
+            "INSERT INTO editions (book_id, language) VALUES ('%1', '%2')")
+            .arg(bookId, language));
+        const int edId = m_db->scalarInt(QStringLiteral(
+            "SELECT id FROM editions WHERE book_id='%1' AND language='%2'")
+            .arg(bookId, language));
+        execSql(db, QStringLiteral(
+            "INSERT INTO formats (edition_id, format_type) VALUES (%1, 'epub')")
+            .arg(edId));
+        const int fmtId = m_db->scalarInt(QStringLiteral(
+            "SELECT id FROM formats WHERE edition_id=%1").arg(edId));
+        execSql(db, QStringLiteral(
+            "INSERT INTO sources (format_id, source_name, download_link) "
+            "VALUES (%1, 'Gutenberg', 'https://gutenberg.org/ebooks/1')")
+            .arg(fmtId));
+        return edId;
+    }
+
+    void addToLibrary(const QString &bookId, int editionId)
+    {
+        execSql(m_db->database(), QStringLiteral(
+            "INSERT INTO library_items (book_id, edition_id, status) "
+            "VALUES ('%1', %2, 'saved')").arg(bookId).arg(editionId));
+    }
+
+    std::unique_ptr<bookhub::tests::TestDatabase> m_db;
+    TestQueryWorker  *m_worker{};
+    LibraryService   *m_libraryService{};
+};
+
+void BookDetailsPanelTest::init()
+{
+    m_db = std::make_unique<bookhub::tests::TestDatabase>();
+    QVERIFY(m_db->open());
+    QVERIFY(m_db->createSchema());
+
+    m_worker = new TestQueryWorker();
+
+    m_libraryService = new LibraryService();
+    m_libraryService->connectToWorker(m_worker);
+}
+
+void BookDetailsPanelTest::cleanup()
+{
+    delete m_libraryService;
+    m_libraryService = nullptr;
+    delete m_worker;
+    m_worker = nullptr;
+    m_db.reset();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void BookDetailsPanelTest::loadBook_populatesMetadata()
+{
+    insertBook(QStringLiteral("test:1"), QStringLiteral("Pride and Prejudice"),
+               QStringLiteral("Jane Austen"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:1"));
+
+    QCOMPARE(panel.m_titleLabel->text(), QStringLiteral("Pride and Prejudice"));
+    QCOMPARE(panel.m_authorLabel->text(), QStringLiteral("Jane Austen"));
+    QVERIFY(panel.m_metaLabel->text().contains(QStringLiteral("1900")));
+}
+
+void BookDetailsPanelTest::loadBook_showsLoadingThenContent()
+{
+    insertBook(QStringLiteral("test:2"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+
+    // Before loadBook: outer stack index is 0 (loading)
+    QCOMPARE(panel.m_outerStack->currentIndex(), 0);
+
+    panel.loadBook(QStringLiteral("test:2"));
+
+    // TestQueryWorker is synchronous — content should be visible immediately
+    QCOMPARE(panel.m_outerStack->currentIndex(), 1);
+}
+
+void BookDetailsPanelTest::loadBook_notInLibrary_showsAddButton()
+{
+    insertBook(QStringLiteral("test:3"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:3"));
+
+    QVERIFY(panel.m_libraryBtn->text().contains(QStringLiteral("Add")));
+    QVERIFY(panel.m_libraryBtn->isEnabled());
+}
+
+void BookDetailsPanelTest::loadBook_inLibrary_showsInLibraryButton()
+{
+    const int edId = insertBook(QStringLiteral("test:4"));
+    addToLibrary(QStringLiteral("test:4"), edId);
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:4"));
+
+    QVERIFY(panel.m_libraryBtn->text().contains(QStringLiteral("In Library")));
+    QVERIFY(panel.m_libraryBtn->isEnabled());
+}
+
+void BookDetailsPanelTest::loadBook_multipleEditions_showsComboBox()
+{
+    const auto &db = m_db->database();
+    execSql(db, QStringLiteral(
+        "INSERT INTO books (book_id, title, author) VALUES ('test:5', 'Multi', 'Auth')"));
+    execSql(db, QStringLiteral(
+        "INSERT INTO editions (book_id, language) VALUES ('test:5', 'en')"));
+    execSql(db, QStringLiteral(
+        "INSERT INTO editions (book_id, language) VALUES ('test:5', 'fr')"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:5"));
+
+    QVERIFY(!panel.m_langCombo->isHidden());
+    QVERIFY(panel.m_singleLangLabel->isHidden());
+    QCOMPARE(panel.m_langCombo->count(), 2);
+}
+
+void BookDetailsPanelTest::loadBook_singleEdition_showsSingleLabel()
+{
+    insertBook(QStringLiteral("test:6"), QStringLiteral("Solo"), QStringLiteral("A"),
+               QStringLiteral("de"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:6"));
+
+    QVERIFY(panel.m_langCombo->isHidden());
+    QVERIFY(!panel.m_singleLangLabel->isHidden());
+    QCOMPARE(panel.m_singleLangLabel->text(), QStringLiteral("de"));
+}
+
+void BookDetailsPanelTest::loadBook_longSummary_showsShowMoreButton()
+{
+    const auto &db = m_db->database();
+    const QString longSummary = QString(400, QChar('x'));
+    execSql(db, QStringLiteral(
+        "INSERT INTO books (book_id, title, summary) VALUES ('test:7', 'Long', '%1')")
+        .arg(longSummary));
+    execSql(db, QStringLiteral(
+        "INSERT INTO editions (book_id, language) VALUES ('test:7', 'en')"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:7"));
+
+    QVERIFY(!panel.m_showMoreBtn->isHidden());
+    QCOMPARE(panel.m_showMoreBtn->text(), QStringLiteral("Show more"));
+}
+
+void BookDetailsPanelTest::loadBook_shortSummary_hidesShowMoreButton()
+{
+    insertBook(QStringLiteral("test:8"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:8"));
+
+    QVERIFY(panel.m_showMoreBtn->isHidden());
+}
+
+void BookDetailsPanelTest::loadBook_populatesFormats()
+{
+    insertBook(QStringLiteral("test:9"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:9"));
+
+    // The formats section should contain at least one row (one format widget)
+    const auto rows = panel.m_formatsWidget->findChildren<QWidget *>(
+        QString(), Qt::FindDirectChildrenOnly);
+    QVERIFY(!rows.isEmpty());
+
+    // The format row should contain a button labelled "[Gutenberg]"
+    const auto buttons = panel.m_formatsWidget->findChildren<QPushButton *>();
+    const bool hasGutenberg = std::any_of(buttons.begin(), buttons.end(),
+        [](QPushButton *b) { return b->text().contains(QStringLiteral("Gutenberg")); });
+    QVERIFY(hasGutenberg);
+}
+
+void BookDetailsPanelTest::addToLibrary_updatesButtonToInLibrary()
+{
+    insertBook(QStringLiteral("test:10"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:10"));
+
+    QVERIFY(panel.m_libraryBtn->text().contains(QStringLiteral("Add")));
+
+    panel.onAddToLibraryClicked();
+
+    QVERIFY(panel.m_libraryBtn->text().contains(QStringLiteral("In Library")));
+    QVERIFY(panel.m_inLibrary);
+    QVERIFY(panel.m_libraryItemId > 0);
+}
+
+void BookDetailsPanelTest::removeFromLibrary_updatesButtonToAdd()
+{
+    const int edId = insertBook(QStringLiteral("test:11"));
+    addToLibrary(QStringLiteral("test:11"), edId);
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:11"));
+
+    QVERIFY(panel.m_libraryBtn->text().contains(QStringLiteral("In Library")));
+
+    panel.onRemoveFromLibraryClicked();
+
+    QVERIFY(panel.m_libraryBtn->text().contains(QStringLiteral("Add")));
+    QVERIFY(!panel.m_inLibrary);
+    QCOMPARE(panel.m_libraryItemId, 0);
+}
+
+void BookDetailsPanelTest::dismissButton_emitsDismissedSignal()
+{
+    insertBook(QStringLiteral("test:12"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    QSignalSpy spy(&panel, &BookDetailsPanel::dismissed);
+
+    auto *backBtn = panel.findChildren<QPushButton *>().first();
+    // find the button with "Back" text
+    auto it = std::find_if(panel.findChildren<QPushButton *>().begin(),
+                           panel.findChildren<QPushButton *>().end(),
+                           [](QPushButton *b) {
+                               return b->text().contains(QStringLiteral("Back"));
+                           });
+    QVERIFY(it != panel.findChildren<QPushButton *>().end());
+    (*it)->click();
+
+    QCOMPARE(spy.count(), 1);
+}
+
+void BookDetailsPanelTest::languageChange_requestsFormatsForNewEdition()
+{
+    const auto &db = m_db->database();
+    execSql(db, QStringLiteral(
+        "INSERT INTO books (book_id, title, author) VALUES ('test:13', 'Bi', 'Auth')"));
+    execSql(db, QStringLiteral(
+        "INSERT INTO editions (book_id, language) VALUES ('test:13', 'en')"));
+    execSql(db, QStringLiteral(
+        "INSERT INTO editions (book_id, language) VALUES ('test:13', 'fr')"));
+    // Add a format for the French edition
+    const int frEdId = m_db->scalarInt(QStringLiteral(
+        "SELECT id FROM editions WHERE book_id='test:13' AND language='fr'"));
+    execSql(db, QStringLiteral(
+        "INSERT INTO formats (edition_id, format_type) VALUES (%1, 'pdf')").arg(frEdId));
+    const int fmtId = m_db->scalarInt(QStringLiteral(
+        "SELECT id FROM formats WHERE edition_id=%1").arg(frEdId));
+    execSql(db, QStringLiteral(
+        "INSERT INTO sources (format_id, source_name, download_link) "
+        "VALUES (%1, 'BNF', 'https://bnf.fr/1')").arg(fmtId));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:13"));
+
+    // Switch to French (index 1 — sorted alphabetically: en=0, fr=1)
+    const int frIndex = panel.m_langCombo->findText(QStringLiteral("fr"));
+    QVERIFY(frIndex >= 0);
+    panel.m_langCombo->setCurrentIndex(frIndex);
+
+    // Formats should now show pdf/BNF
+    const auto buttons = panel.m_formatsWidget->findChildren<QPushButton *>();
+    const bool hasBnf = std::any_of(buttons.begin(), buttons.end(),
+        [](QPushButton *b) { return b->text().contains(QStringLiteral("BNF")); });
+    QVERIFY(hasBnf);
+}
+
+void BookDetailsPanelTest::showMore_expandsAndCollapsesSummary()
+{
+    const auto &db = m_db->database();
+    const QString longSummary = QString(400, QChar('a'));
+    execSql(db, QStringLiteral(
+        "INSERT INTO books (book_id, title, summary) VALUES ('test:14', 'S', '%1')")
+        .arg(longSummary));
+    execSql(db, QStringLiteral(
+        "INSERT INTO editions (book_id, language) VALUES ('test:14', 'en')"));
+
+    BookDetailsPanel panel(m_libraryService, m_worker);
+    panel.loadBook(QStringLiteral("test:14"));
+
+    QVERIFY(!panel.m_showMoreBtn->isHidden());
+    // Initially collapsed
+    QVERIFY(panel.m_summaryLabel->text().endsWith(QStringLiteral("…")));
+
+    panel.m_showMoreBtn->click(); // expand
+    QCOMPARE(panel.m_summaryLabel->text(), longSummary);
+    QCOMPARE(panel.m_showMoreBtn->text(), QStringLiteral("Show less"));
+
+    panel.m_showMoreBtn->click(); // collapse
+    QVERIFY(panel.m_summaryLabel->text().endsWith(QStringLiteral("…")));
+    QCOMPARE(panel.m_showMoreBtn->text(), QStringLiteral("Show more"));
+}
+
+QTEST_MAIN(BookDetailsPanelTest)
+#include "test_book_details_panel.moc"

--- a/tests/support/test_query_worker.h
+++ b/tests/support/test_query_worker.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include "gui/query_worker.h"
-#include "gui/services/search_service.h"
-#include "gui/services/library_service.h"
+#include "gui/services/book_details_service.h"
 #include "gui/services/explore_service.h"
+#include "gui/services/library_service.h"
+#include "gui/services/search_service.h"
 
 #include <QSqlDatabase>
 
@@ -107,6 +108,19 @@ public slots:
         emit booksForGenreCompleted(requestId,
             internal::fetchBooksForGenre(genre, offset, limit,
                                          QSqlDatabase::defaultConnection));
+    }
+
+    void handleBookDetailsRequest(quint64 requestId, QString bookId) override
+    {
+        emit bookDetailsCompleted(requestId,
+            internal::fetchBookDetails(bookId, QSqlDatabase::defaultConnection));
+    }
+
+    void handleFormatsForEditionRequest(quint64 requestId, int editionId) override
+    {
+        emit formatsForEditionCompleted(requestId,
+            internal::fetchFormatsForEdition(editionId,
+                                             QSqlDatabase::defaultConnection));
     }
 };
 


### PR DESCRIPTION
## Summary

- Adds `BookDetailsPanel` as the right pane of a `QSplitter` in `MainWindow` (hidden until a book is clicked, then shown at 50/50 split)
- Adds `BookDetailsService` with `fetchBookDetails` / `fetchFormatsForEdition` SQL queries and two new `QueryWorker` virtual slots
- Panel displays: title, author, year+genres, language selector (combo for multi-edition, badge label for single), collapsible summary, formats+source buttons, and Add/Remove Library action bar
- Wires `bookDetailsRequested` signal from Library, Search, and Explore screens — previously left as TODO lambdas
- 14 `QtTest` tests in `tests/gui/test_book_details_panel.cpp`; all pass (6/6 sanity suite green)

## Test plan

- [x] `ctest -L details` — 16/16 pass
- [x] `ctest -L sanity` — 6/6 pass
- [x] Full build with no warnings (`make -j$(nproc)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)