### PR TITLE
feat: implement Task 11 download flow dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ reviews/
 Thumbs.db.codex
 claude/
 .claude/
+
+# Qt test artifacts
+Testing/
 # GitHub agent files (local, not for repo)
 .github/agents/
 .github/instructions/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,4 +130,4 @@ label_bookhub_test(test_book_details_panel sanity gui details)
 add_bookhub_test(test_download_flow_dialog
     tests/gui/test_download_flow_dialog.cpp
 )
-label_bookhub_test(test_download_flow_dialog gui download)
+label_bookhub_test(test_download_flow_dialog sanity gui download)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(COLLECTOR_SOURCES
 )
 
 set(GUI_SOURCES
+    src/gui/dialogs/download_flow_dialog.cpp
     src/gui/main_window.cpp
     src/gui/panels/book_details_panel.cpp
     src/gui/screens/explore_screen.cpp
@@ -125,3 +126,8 @@ add_bookhub_test(test_book_details_panel
     tests/gui/test_book_details_panel.cpp
 )
 label_bookhub_test(test_book_details_panel sanity gui details)
+
+add_bookhub_test(test_download_flow_dialog
+    tests/gui/test_download_flow_dialog.cpp
+)
+label_bookhub_test(test_download_flow_dialog gui download)

--- a/src/collector/book_discovery_service.cpp
+++ b/src/collector/book_discovery_service.cpp
@@ -30,7 +30,7 @@ void BookDiscoveryService::startDiscovery() {
     }
 
     const bool wasIdle = (m_activeFetches == 0);
-    m_activeFetches += m_adapters.size();
+    m_activeFetches += static_cast<int>(m_adapters.size());
     if (wasIdle) {
         emit updateStarted();
     }
@@ -75,7 +75,7 @@ void BookDiscoveryService::onFetchCompleted(bool success, const QString& errorMe
 
 static int idPriority(const QString& bookId)
 {
-    const int colon = bookId.indexOf(':');
+    const qsizetype colon = bookId.indexOf(':');
     const QString prefix = (colon >= 0) ? bookId.left(colon) : bookId;
     if (prefix == "lccn")  return 1;
     if (prefix == "oclc")  return 2;

--- a/src/collector/gutenberg_adapter.cpp
+++ b/src/collector/gutenberg_adapter.cpp
@@ -268,7 +268,7 @@ void GutenbergAdapter::parseSingleRdf(const QByteArray& data, const QString& ent
             // Extract the raw LCCN value and normalize it; store only the digits+alpha, no prefix
             QString lccnNormalized = normalizeLccn(raw);
             // lccnNormalized is "lccn:XYZ" — store just the part after the colon as value
-            int colon = lccnNormalized.indexOf(':');
+            qsizetype colon = lccnNormalized.indexOf(':');
             if (colon >= 0) {
                 book.identifiers.append(BookIdentifier{"lccn", lccnNormalized.mid(colon + 1)});
             }

--- a/src/gui/dialogs/download_flow_dialog.cpp
+++ b/src/gui/dialogs/download_flow_dialog.cpp
@@ -19,7 +19,6 @@
 #include <QRegularExpression>
 #include <QSaveFile>
 #include <QSettings>
-#include <QStackedLayout>
 #include <QUrl>
 #include <QVBoxLayout>
 
@@ -261,7 +260,9 @@ void DownloadFlowDialog::buildUi()
     root->addWidget(m_stepLabel);
 
     auto *stackHost = new QWidget(this);
-    auto *stackLayout = new QStackedLayout(stackHost);
+    auto *stackLayout = new QVBoxLayout(stackHost);
+    stackLayout->setContentsMargins(0, 0, 0, 0);
+    stackLayout->setSpacing(0);
     root->addWidget(stackHost, 1);
 
     m_stepsContainer = new QWidget(stackHost);
@@ -517,6 +518,10 @@ QString DownloadFlowDialog::sanitizeFileName(const QString &name) const
 
 void DownloadFlowDialog::showErrorState(const QString &message)
 {
+    m_stepsContainer->hide();
+    m_progressContainer->show();
+    m_stepLabel->setText(QStringLiteral("Error"));
+    m_backBtn->setVisible(false);
     m_resultLabel->setText(message);
     m_nextBtn->setText(QStringLiteral("Close"));
     m_nextBtn->setEnabled(true);

--- a/src/gui/dialogs/download_flow_dialog.cpp
+++ b/src/gui/dialogs/download_flow_dialog.cpp
@@ -1,0 +1,515 @@
+#include "download_flow_dialog.h"
+
+#include "../query_worker.h"
+#include "../services/library_service.h"
+
+#include <QDesktopServices>
+#include <QDialogButtonBox>
+#include <QDir>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QMessageBox>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QSettings>
+#include <QStackedLayout>
+#include <QUrl>
+#include <QVBoxLayout>
+
+namespace bookhub::gui {
+
+namespace {
+constexpr auto kLastDownloadDirKey = "download/lastDirectory";
+constexpr int kSourceNameRole = Qt::UserRole;
+constexpr int kSourceUrlRole  = Qt::UserRole + 1;
+}
+
+DownloadFlowDialog::DownloadFlowDialog(LibraryService *libraryService,
+                                       QueryWorker    *worker,
+                                       QWidget        *parent)
+    : QDialog(parent)
+    , m_libraryService(libraryService)
+{
+    setModal(true);
+    setWindowTitle(QStringLiteral("Download"));
+    resize(520, 420);
+
+    m_network = new QNetworkAccessManager(this);
+    m_detailsService = new BookDetailsService(this);
+    m_detailsService->connectToWorker(worker);
+
+    buildUi();
+    resetState();
+
+    connect(m_detailsService, &BookDetailsService::detailsCompleted,
+            this, &DownloadFlowDialog::onDetailsCompleted);
+    connect(m_detailsService, &BookDetailsService::formatsCompleted,
+            this, &DownloadFlowDialog::onFormatsCompleted);
+}
+
+void DownloadFlowDialog::startForBook(const QString &bookId)
+{
+    resetState();
+    m_bookId = bookId;
+    m_pendingDetailsId = m_detailsService->peekNextId();
+    m_detailsService->requestBookDetails(bookId);
+    exec();
+}
+
+void DownloadFlowDialog::onDetailsCompleted(quint64 requestId, BookDetails details)
+{
+    if (requestId != m_pendingDetailsId)
+        return;
+
+    m_bookTitle = details.title;
+    m_libraryItemId = details.libraryItemId;
+    m_editions = details.editions;
+    m_hasLanguageStep = m_editions.size() > 1;
+    m_titleLabel->setText(QStringLiteral("Download - %1").arg(m_bookTitle));
+
+    populateLanguageList();
+
+    if (m_editions.isEmpty()) {
+        showErrorState(QStringLiteral("No language editions are available for this book."));
+        return;
+    }
+
+    if (!m_hasLanguageStep) {
+        m_languageList->setCurrentRow(0);
+        requestFormatsForSelectedLanguage();
+        m_currentStep = 1;
+    } else {
+        m_currentStep = 0;
+    }
+    updateStepUi();
+}
+
+void DownloadFlowDialog::onFormatsCompleted(quint64 requestId, QList<BookFormatEntry> formats)
+{
+    if (requestId != m_pendingFormatsId)
+        return;
+    m_formats = formats;
+    populateFormatList();
+    if (!m_hasLanguageStep && m_currentStep < 1) {
+        m_currentStep = 1;
+    }
+    updateStepUi();
+}
+
+void DownloadFlowDialog::onLanguageSelectionChanged()
+{
+    if (m_languageList->currentRow() < 0)
+        return;
+    m_formats.clear();
+    m_formatList->clear();
+    m_sourceList->clear();
+    requestFormatsForSelectedLanguage();
+    updateStepUi();
+}
+
+void DownloadFlowDialog::onFormatSelectionChanged()
+{
+    populateSourceList();
+    updateStepUi();
+}
+
+void DownloadFlowDialog::onSourceSelectionChanged()
+{
+    updateStepUi();
+}
+
+void DownloadFlowDialog::onBackClicked()
+{
+    if (m_currentStep <= (m_hasLanguageStep ? 0 : 1))
+        return;
+    --m_currentStep;
+    updateStepUi();
+}
+
+void DownloadFlowDialog::onNextOrDownloadClicked()
+{
+    if (m_currentStep == 0) {
+        if (m_languageList->currentRow() < 0)
+            return;
+        m_currentStep = 1;
+    } else if (m_currentStep == 1) {
+        if (m_formatList->currentRow() < 0)
+            return;
+        m_currentStep = 2;
+    } else if (m_currentStep == 2) {
+        if (m_sourceList->currentRow() < 0)
+            return;
+        beginDownload();
+        return;
+    }
+    updateStepUi();
+}
+
+void DownloadFlowDialog::onCancelDownloadClicked()
+{
+    if (m_reply) {
+        m_reply->abort();
+        return;
+    }
+    reject();
+}
+
+void DownloadFlowDialog::onOpenFileClicked()
+{
+    if (!m_targetFilePath.isEmpty())
+        QDesktopServices::openUrl(QUrl::fromLocalFile(m_targetFilePath));
+}
+
+void DownloadFlowDialog::onDownloadReadyRead()
+{
+    if (!m_reply || !m_outputFile)
+        return;
+    const QByteArray data = m_reply->readAll();
+    if (m_outputFile->write(data) != data.size()) {
+        showErrorState(QStringLiteral("Failed to write downloaded data to disk."));
+        m_reply->abort();
+    }
+}
+
+void DownloadFlowDialog::onDownloadProgress(qint64 received, qint64 total)
+{
+    if (total > 0) {
+        m_progressBar->setRange(0, 100);
+        m_progressBar->setValue(static_cast<int>((received * 100) / total));
+        m_progressText->setText(QStringLiteral("%1 / %2 bytes")
+                                    .arg(received)
+                                    .arg(total));
+    } else {
+        m_progressBar->setRange(0, 0);
+        m_progressText->setText(QStringLiteral("%1 bytes").arg(received));
+    }
+}
+
+void DownloadFlowDialog::onDownloadFinished()
+{
+    if (!m_reply)
+        return;
+
+    const bool hadError = m_reply->error() != QNetworkReply::NoError;
+    const QString err = m_reply->errorString();
+    m_reply->deleteLater();
+    m_reply = nullptr;
+
+    m_cancelBtn->setEnabled(false);
+
+    if (hadError) {
+        if (m_outputFile) {
+            m_outputFile->cancelWriting();
+            delete m_outputFile;
+            m_outputFile = nullptr;
+        }
+        setLibraryStatus(QStringLiteral("error"));
+        showErrorState(QStringLiteral("Download failed: %1").arg(err));
+        return;
+    }
+
+    if (!m_outputFile || !m_outputFile->commit()) {
+        if (m_outputFile) {
+            delete m_outputFile;
+            m_outputFile = nullptr;
+        }
+        setLibraryStatus(QStringLiteral("error"));
+        showErrorState(QStringLiteral("Failed to finalize downloaded file."));
+        return;
+    }
+
+    delete m_outputFile;
+    m_outputFile = nullptr;
+
+    QFileInfo info(m_targetFilePath);
+    QSettings settings;
+    settings.setValue(QString::fromLatin1(kLastDownloadDirKey), info.absolutePath());
+
+    setLibraryStatus(QStringLiteral("downloaded"));
+    m_resultLabel->setText(QStringLiteral("Download complete."));
+    m_openFileBtn->setVisible(true);
+    m_nextBtn->setText(QStringLiteral("Close"));
+    disconnect(m_nextBtn, &QPushButton::clicked,
+               this, &DownloadFlowDialog::onNextOrDownloadClicked);
+    connect(m_nextBtn, &QPushButton::clicked, this, &QDialog::accept);
+}
+
+void DownloadFlowDialog::buildUi()
+{
+    auto *root = new QVBoxLayout(this);
+
+    m_titleLabel = new QLabel(this);
+    root->addWidget(m_titleLabel);
+
+    m_stepLabel = new QLabel(this);
+    root->addWidget(m_stepLabel);
+
+    auto *stackHost = new QWidget(this);
+    auto *stackLayout = new QStackedLayout(stackHost);
+    root->addWidget(stackHost, 1);
+
+    m_stepsContainer = new QWidget(stackHost);
+    auto *stepsLayout = new QVBoxLayout(m_stepsContainer);
+
+    m_languageList = new QListWidget(m_stepsContainer);
+    m_languageList->setSelectionMode(QAbstractItemView::SingleSelection);
+    stepsLayout->addWidget(m_languageList);
+    connect(m_languageList, &QListWidget::itemSelectionChanged,
+            this, &DownloadFlowDialog::onLanguageSelectionChanged);
+
+    m_formatList = new QListWidget(m_stepsContainer);
+    m_formatList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_formatList->hide();
+    stepsLayout->addWidget(m_formatList);
+    connect(m_formatList, &QListWidget::itemSelectionChanged,
+            this, &DownloadFlowDialog::onFormatSelectionChanged);
+
+    m_sourceList = new QListWidget(m_stepsContainer);
+    m_sourceList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_sourceList->hide();
+    stepsLayout->addWidget(m_sourceList);
+    connect(m_sourceList, &QListWidget::itemSelectionChanged,
+            this, &DownloadFlowDialog::onSourceSelectionChanged);
+
+    m_progressContainer = new QWidget(stackHost);
+    auto *progressLayout = new QVBoxLayout(m_progressContainer);
+    m_progressBar = new QProgressBar(m_progressContainer);
+    m_progressText = new QLabel(m_progressContainer);
+    m_progressPathLabel = new QLabel(m_progressContainer);
+    m_resultLabel = new QLabel(m_progressContainer);
+    m_resultLabel->setWordWrap(true);
+    m_openFileBtn = new QPushButton(QStringLiteral("Open file"), m_progressContainer);
+    m_openFileBtn->hide();
+    connect(m_openFileBtn, &QPushButton::clicked, this, &DownloadFlowDialog::onOpenFileClicked);
+    progressLayout->addWidget(m_progressBar);
+    progressLayout->addWidget(m_progressText);
+    progressLayout->addWidget(m_progressPathLabel);
+    progressLayout->addWidget(m_resultLabel);
+    progressLayout->addWidget(m_openFileBtn, 0, Qt::AlignLeft);
+    progressLayout->addStretch();
+
+    stackLayout->addWidget(m_stepsContainer);
+    stackLayout->addWidget(m_progressContainer);
+
+    auto *buttons = new QHBoxLayout();
+    root->addLayout(buttons);
+
+    m_backBtn = new QPushButton(QStringLiteral("Back"), this);
+    m_nextBtn = new QPushButton(QStringLiteral("Next"), this);
+    m_cancelBtn = new QPushButton(QStringLiteral("Cancel"), this);
+    buttons->addWidget(m_backBtn);
+    buttons->addStretch();
+    buttons->addWidget(m_cancelBtn);
+    buttons->addWidget(m_nextBtn);
+
+    connect(m_backBtn, &QPushButton::clicked, this, &DownloadFlowDialog::onBackClicked);
+    connect(m_nextBtn, &QPushButton::clicked, this, &DownloadFlowDialog::onNextOrDownloadClicked);
+    connect(m_cancelBtn, &QPushButton::clicked, this, &DownloadFlowDialog::onCancelDownloadClicked);
+}
+
+void DownloadFlowDialog::resetState()
+{
+    m_bookId.clear();
+    m_bookTitle.clear();
+    m_libraryItemId = 0;
+    m_editions.clear();
+    m_formats.clear();
+    m_hasLanguageStep = false;
+    m_currentStep = 0;
+    m_targetFilePath.clear();
+    m_lastError.clear();
+    m_languageList->clear();
+    m_formatList->clear();
+    m_sourceList->clear();
+    m_progressBar->setRange(0, 100);
+    m_progressBar->setValue(0);
+    m_progressText->setText(QStringLiteral("Waiting to start..."));
+    m_progressPathLabel->clear();
+    m_resultLabel->clear();
+    m_openFileBtn->hide();
+    m_cancelBtn->setEnabled(true);
+    m_stepsContainer->show();
+    m_progressContainer->hide();
+    m_titleLabel->setText(QStringLiteral("Loading..."));
+    m_nextBtn->setText(QStringLiteral("Next"));
+    m_backBtn->setVisible(false);
+    disconnect(m_nextBtn, &QPushButton::clicked, this, &QDialog::accept);
+    connect(m_nextBtn, &QPushButton::clicked, this, &DownloadFlowDialog::onNextOrDownloadClicked,
+            Qt::UniqueConnection);
+}
+
+void DownloadFlowDialog::updateStepUi()
+{
+    m_stepsContainer->setVisible(true);
+    m_progressContainer->setVisible(false);
+
+    m_languageList->setVisible(m_currentStep == 0);
+    m_formatList->setVisible(m_currentStep == 1);
+    m_sourceList->setVisible(m_currentStep == 2);
+
+    if (m_currentStep == 0) {
+        m_stepLabel->setText(QStringLiteral("Step 1 of 3: Language"));
+        m_nextBtn->setText(QStringLiteral("Next"));
+        m_nextBtn->setEnabled(m_languageList->currentRow() >= 0);
+    } else if (m_currentStep == 1) {
+        m_stepLabel->setText(QStringLiteral("Step 2 of 3: Format"));
+        m_nextBtn->setText(QStringLiteral("Next"));
+        m_nextBtn->setEnabled(m_formatList->currentRow() >= 0);
+    } else {
+        m_stepLabel->setText(QStringLiteral("Step 3 of 3: Source"));
+        m_nextBtn->setText(QStringLiteral("Download"));
+        m_nextBtn->setEnabled(m_sourceList->currentRow() >= 0);
+    }
+
+    const int minStep = m_hasLanguageStep ? 0 : 1;
+    m_backBtn->setVisible(m_currentStep > minStep);
+}
+
+void DownloadFlowDialog::populateLanguageList()
+{
+    m_languageList->clear();
+    for (const auto &edition : m_editions) {
+        auto *item = new QListWidgetItem(edition.language, m_languageList);
+        item->setData(Qt::UserRole, edition.editionId);
+    }
+    if (!m_editions.isEmpty())
+        m_languageList->setCurrentRow(0);
+}
+
+void DownloadFlowDialog::populateFormatList()
+{
+    m_formatList->clear();
+    for (const auto &format : m_formats)
+        m_formatList->addItem(format.formatType);
+    if (m_formatList->count() > 0)
+        m_formatList->setCurrentRow(0);
+}
+
+void DownloadFlowDialog::populateSourceList()
+{
+    m_sourceList->clear();
+    if (m_formatList->currentRow() < 0 || m_formatList->currentRow() >= m_formats.size())
+        return;
+    const auto &format = m_formats.at(m_formatList->currentRow());
+    for (const auto &source : format.sources) {
+        auto *item = new QListWidgetItem(source.sourceName, m_sourceList);
+        item->setData(kSourceNameRole, source.sourceName);
+        item->setData(kSourceUrlRole, source.downloadLink);
+    }
+    if (m_sourceList->count() > 0)
+        m_sourceList->setCurrentRow(0);
+}
+
+void DownloadFlowDialog::requestFormatsForSelectedLanguage()
+{
+    const auto *item = m_languageList->currentItem();
+    if (!item)
+        return;
+    const int editionId = item->data(Qt::UserRole).toInt();
+    m_pendingFormatsId = m_detailsService->peekNextId();
+    m_detailsService->requestFormatsForEdition(editionId);
+}
+
+bool DownloadFlowDialog::beginDownload()
+{
+    const auto source = selectedSource();
+    if (source.downloadLink.isEmpty())
+        return false;
+
+    const QString savePath = QFileDialog::getSaveFileName(
+        this,
+        QStringLiteral("Save file"),
+        suggestedFilePath());
+    if (savePath.isEmpty())
+        return false;
+
+    m_targetFilePath = savePath;
+    m_outputFile = new QSaveFile(m_targetFilePath);
+    if (!m_outputFile->open(QIODevice::WriteOnly)) {
+        delete m_outputFile;
+        m_outputFile = nullptr;
+        showErrorState(QStringLiteral("Cannot open target file for writing."));
+        return false;
+    }
+
+    m_stepsContainer->hide();
+    m_progressContainer->show();
+    m_stepLabel->setText(QStringLiteral("Downloading..."));
+    m_progressPathLabel->setText(QStringLiteral("Saving to: %1").arg(m_targetFilePath));
+    m_backBtn->setVisible(false);
+    m_nextBtn->setEnabled(false);
+    m_cancelBtn->setEnabled(true);
+    m_openFileBtn->hide();
+    m_resultLabel->clear();
+
+    setLibraryStatus(QStringLiteral("downloading"));
+
+    QNetworkRequest request(QUrl(source.downloadLink));
+    m_reply = m_network->get(request);
+    connect(m_reply, &QNetworkReply::readyRead, this, &DownloadFlowDialog::onDownloadReadyRead);
+    connect(m_reply, &QNetworkReply::downloadProgress, this, &DownloadFlowDialog::onDownloadProgress);
+    connect(m_reply, &QNetworkReply::finished, this, &DownloadFlowDialog::onDownloadFinished);
+    return true;
+}
+
+QString DownloadFlowDialog::suggestedFilePath() const
+{
+    QSettings settings;
+    const QString dir = settings.value(QString::fromLatin1(kLastDownloadDirKey), QDir::homePath())
+                            .toString();
+    QString extension = QStringLiteral("bin");
+    if (m_formatList->currentItem())
+        extension = m_formatList->currentItem()->text().toLower();
+
+    const QString fileName = QStringLiteral("%1.%2")
+                                 .arg(sanitizeFileName(m_bookTitle))
+                                 .arg(extension);
+    return QDir(dir).filePath(fileName);
+}
+
+QString DownloadFlowDialog::sanitizeFileName(const QString &name) const
+{
+    QString cleaned = name.trimmed();
+    cleaned.replace(QRegularExpression(QStringLiteral(R"([\\/:*?"<>|])")),
+                    QStringLiteral("_"));
+    if (cleaned.isEmpty())
+        cleaned = QStringLiteral("book");
+    return cleaned;
+}
+
+void DownloadFlowDialog::showErrorState(const QString &message)
+{
+    m_lastError = message;
+    m_resultLabel->setText(message);
+    m_nextBtn->setText(QStringLiteral("Close"));
+    m_nextBtn->setEnabled(true);
+    disconnect(m_nextBtn, &QPushButton::clicked,
+               this, &DownloadFlowDialog::onNextOrDownloadClicked);
+    connect(m_nextBtn, &QPushButton::clicked, this, &QDialog::reject, Qt::UniqueConnection);
+}
+
+void DownloadFlowDialog::setLibraryStatus(const QString &status)
+{
+    if (m_libraryItemId > 0)
+        m_libraryService->requestUpdateStatus(m_libraryItemId, status);
+}
+
+BookSourceEntry DownloadFlowDialog::selectedSource() const
+{
+    const auto *item = m_sourceList->currentItem();
+    if (!item)
+        return {};
+    BookSourceEntry src;
+    src.sourceName = item->data(kSourceNameRole).toString();
+    src.downloadLink = item->data(kSourceUrlRole).toString();
+    return src;
+}
+
+} // namespace bookhub::gui

--- a/src/gui/dialogs/download_flow_dialog.cpp
+++ b/src/gui/dialogs/download_flow_dialog.cpp
@@ -29,6 +29,17 @@ namespace {
 constexpr auto kLastDownloadDirKey = "download/lastDirectory";
 constexpr int kSourceNameRole = Qt::UserRole;
 constexpr int kSourceUrlRole  = Qt::UserRole + 1;
+constexpr auto kStatusDownloading = "downloading";
+constexpr auto kStatusDownloaded = "downloaded";
+constexpr auto kStatusError = "error";
+
+QString formatSize(qint64 bytes) {
+    if (bytes >= 1024 * 1024)
+        return QStringLiteral("%1 MB").arg(bytes / (1024.0 * 1024), 0, 'f', 1);
+    if (bytes >= 1024)
+        return QStringLiteral("%1 KB").arg(bytes / 1024.0, 0, 'f', 1);
+    return QStringLiteral("%1 bytes").arg(bytes);
+}
 }
 
 DownloadFlowDialog::DownloadFlowDialog(LibraryService *libraryService,
@@ -82,8 +93,6 @@ void DownloadFlowDialog::onDetailsCompleted(quint64 requestId, BookDetails detai
     }
 
     if (!m_hasLanguageStep) {
-        m_languageList->setCurrentRow(0);
-        requestFormatsForSelectedLanguage();
         m_currentStep = 1;
     } else {
         m_currentStep = 0;
@@ -183,12 +192,12 @@ void DownloadFlowDialog::onDownloadProgress(qint64 received, qint64 total)
     if (total > 0) {
         m_progressBar->setRange(0, 100);
         m_progressBar->setValue(static_cast<int>((received * 100) / total));
-        m_progressText->setText(QStringLiteral("%1 / %2 bytes")
-                                    .arg(received)
-                                    .arg(total));
+        m_progressText->setText(QStringLiteral("%1 / %2")
+                                    .arg(formatSize(received))
+                                    .arg(formatSize(total)));
     } else {
         m_progressBar->setRange(0, 0);
-        m_progressText->setText(QStringLiteral("%1 bytes").arg(received));
+        m_progressText->setText(formatSize(received));
     }
 }
 
@@ -210,7 +219,7 @@ void DownloadFlowDialog::onDownloadFinished()
             delete m_outputFile;
             m_outputFile = nullptr;
         }
-        setLibraryStatus(QStringLiteral("error"));
+        setLibraryStatus(kStatusError);
         showErrorState(QStringLiteral("Download failed: %1").arg(err));
         return;
     }
@@ -220,7 +229,7 @@ void DownloadFlowDialog::onDownloadFinished()
             delete m_outputFile;
             m_outputFile = nullptr;
         }
-        setLibraryStatus(QStringLiteral("error"));
+        setLibraryStatus(kStatusError);
         showErrorState(QStringLiteral("Failed to finalize downloaded file."));
         return;
     }
@@ -232,7 +241,7 @@ void DownloadFlowDialog::onDownloadFinished()
     QSettings settings;
     settings.setValue(QString::fromLatin1(kLastDownloadDirKey), info.absolutePath());
 
-    setLibraryStatus(QStringLiteral("downloaded"));
+    setLibraryStatus(kStatusDownloaded);
     m_resultLabel->setText(QStringLiteral("Download complete."));
     m_openFileBtn->setVisible(true);
     m_nextBtn->setText(QStringLiteral("Close"));
@@ -324,7 +333,6 @@ void DownloadFlowDialog::resetState()
     m_hasLanguageStep = false;
     m_currentStep = 0;
     m_targetFilePath.clear();
-    m_lastError.clear();
     m_languageList->clear();
     m_formatList->clear();
     m_sourceList->clear();
@@ -341,6 +349,7 @@ void DownloadFlowDialog::resetState()
     m_nextBtn->setText(QStringLiteral("Next"));
     m_backBtn->setVisible(false);
     disconnect(m_nextBtn, &QPushButton::clicked, this, &QDialog::accept);
+    disconnect(m_nextBtn, &QPushButton::clicked, this, &QDialog::reject);
     connect(m_nextBtn, &QPushButton::clicked, this, &DownloadFlowDialog::onNextOrDownloadClicked,
             Qt::UniqueConnection);
 }
@@ -354,18 +363,30 @@ void DownloadFlowDialog::updateStepUi()
     m_formatList->setVisible(m_currentStep == 1);
     m_sourceList->setVisible(m_currentStep == 2);
 
-    if (m_currentStep == 0) {
-        m_stepLabel->setText(QStringLiteral("Step 1 of 3: Language"));
-        m_nextBtn->setText(QStringLiteral("Next"));
-        m_nextBtn->setEnabled(m_languageList->currentRow() >= 0);
-    } else if (m_currentStep == 1) {
-        m_stepLabel->setText(QStringLiteral("Step 2 of 3: Format"));
-        m_nextBtn->setText(QStringLiteral("Next"));
-        m_nextBtn->setEnabled(m_formatList->currentRow() >= 0);
+    if (m_hasLanguageStep) {
+        if (m_currentStep == 0) {
+            m_stepLabel->setText(QStringLiteral("Step 1 of 3: Language"));
+            m_nextBtn->setText(QStringLiteral("Next"));
+            m_nextBtn->setEnabled(m_languageList->currentRow() >= 0);
+        } else if (m_currentStep == 1) {
+            m_stepLabel->setText(QStringLiteral("Step 2 of 3: Format"));
+            m_nextBtn->setText(QStringLiteral("Next"));
+            m_nextBtn->setEnabled(m_formatList->currentRow() >= 0);
+        } else {
+            m_stepLabel->setText(QStringLiteral("Step 3 of 3: Source"));
+            m_nextBtn->setText(QStringLiteral("Download"));
+            m_nextBtn->setEnabled(m_sourceList->currentRow() >= 0);
+        }
     } else {
-        m_stepLabel->setText(QStringLiteral("Step 3 of 3: Source"));
-        m_nextBtn->setText(QStringLiteral("Download"));
-        m_nextBtn->setEnabled(m_sourceList->currentRow() >= 0);
+        if (m_currentStep == 1) {
+            m_stepLabel->setText(QStringLiteral("Step 1 of 2: Format"));
+            m_nextBtn->setText(QStringLiteral("Next"));
+            m_nextBtn->setEnabled(m_formatList->currentRow() >= 0);
+        } else {
+            m_stepLabel->setText(QStringLiteral("Step 2 of 2: Source"));
+            m_nextBtn->setText(QStringLiteral("Download"));
+            m_nextBtn->setEnabled(m_sourceList->currentRow() >= 0);
+        }
     }
 
     const int minStep = m_hasLanguageStep ? 0 : 1;
@@ -423,6 +444,12 @@ bool DownloadFlowDialog::beginDownload()
     if (source.downloadLink.isEmpty())
         return false;
 
+    QUrl downloadUrl(source.downloadLink);
+    if (!downloadUrl.isValid() || downloadUrl.scheme() != QStringLiteral("https")) {
+        showErrorState(QStringLiteral("Invalid or unsupported download URL."));
+        return false;
+    }
+
     const QString savePath = QFileDialog::getSaveFileName(
         this,
         QStringLiteral("Save file"),
@@ -449,9 +476,11 @@ bool DownloadFlowDialog::beginDownload()
     m_openFileBtn->hide();
     m_resultLabel->clear();
 
-    setLibraryStatus(QStringLiteral("downloading"));
+    setLibraryStatus(kStatusDownloading);
 
-    QNetworkRequest request(QUrl(source.downloadLink));
+    QNetworkRequest request(downloadUrl);
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                         QNetworkRequest::NoLessSafeRedirectPolicy);
     m_reply = m_network->get(request);
     connect(m_reply, &QNetworkReply::readyRead, this, &DownloadFlowDialog::onDownloadReadyRead);
     connect(m_reply, &QNetworkReply::downloadProgress, this, &DownloadFlowDialog::onDownloadProgress);
@@ -479,6 +508,8 @@ QString DownloadFlowDialog::sanitizeFileName(const QString &name) const
     QString cleaned = name.trimmed();
     cleaned.replace(QRegularExpression(QStringLiteral(R"([\\/:*?"<>|])")),
                     QStringLiteral("_"));
+    if (cleaned.size() > 200)
+        cleaned = cleaned.left(200);
     if (cleaned.isEmpty())
         cleaned = QStringLiteral("book");
     return cleaned;
@@ -486,7 +517,6 @@ QString DownloadFlowDialog::sanitizeFileName(const QString &name) const
 
 void DownloadFlowDialog::showErrorState(const QString &message)
 {
-    m_lastError = message;
     m_resultLabel->setText(message);
     m_nextBtn->setText(QStringLiteral("Close"));
     m_nextBtn->setEnabled(true);

--- a/src/gui/dialogs/download_flow_dialog.cpp
+++ b/src/gui/dialogs/download_flow_dialog.cpp
@@ -33,10 +33,10 @@ constexpr auto kStatusDownloaded = "downloaded";
 constexpr auto kStatusError = "error";
 
 QString formatSize(qint64 bytes) {
-    if (bytes >= 1024 * 1024)
-        return QStringLiteral("%1 MB").arg(bytes / (1024.0 * 1024), 0, 'f', 1);
+    if (bytes >= qint64{1024} * 1024)
+        return QStringLiteral("%1 MB").arg(static_cast<double>(bytes) / (1024.0 * 1024), 0, 'f', 1);
     if (bytes >= 1024)
-        return QStringLiteral("%1 KB").arg(bytes / 1024.0, 0, 'f', 1);
+        return QStringLiteral("%1 KB").arg(static_cast<double>(bytes) / 1024.0, 0, 'f', 1);
     return QStringLiteral("%1 bytes").arg(bytes);
 }
 }
@@ -73,7 +73,7 @@ void DownloadFlowDialog::startForBook(const QString &bookId)
     exec();
 }
 
-void DownloadFlowDialog::onDetailsCompleted(quint64 requestId, BookDetails details)
+void DownloadFlowDialog::onDetailsCompleted(quint64 requestId, const BookDetails &details)
 {
     if (requestId != m_pendingDetailsId)
         return;
@@ -103,7 +103,7 @@ void DownloadFlowDialog::onFormatsCompleted(quint64 requestId, QList<BookFormatE
 {
     if (requestId != m_pendingFormatsId)
         return;
-    m_formats = formats;
+    m_formats = std::move(formats);
     populateFormatList();
     if (!m_hasLanguageStep && m_currentStep < 1) {
         m_currentStep = 1;

--- a/src/gui/dialogs/download_flow_dialog.h
+++ b/src/gui/dialogs/download_flow_dialog.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "../services/book_details_service.h"
+
+#include <QDialog>
+
+class QLabel;
+class QListWidget;
+class QPushButton;
+class QProgressBar;
+class QSaveFile;
+class QNetworkAccessManager;
+class QNetworkReply;
+
+namespace bookhub::gui {
+
+class LibraryService;
+class QueryWorker;
+class DownloadFlowDialogTest;
+
+class DownloadFlowDialog : public QDialog {
+    Q_OBJECT
+public:
+    explicit DownloadFlowDialog(LibraryService *libraryService,
+                                QueryWorker    *worker,
+                                QWidget        *parent = nullptr);
+
+    void startForBook(const QString &bookId);
+
+private slots:
+    void onDetailsCompleted(quint64 requestId, bookhub::gui::BookDetails details);
+    void onFormatsCompleted(quint64 requestId,
+                            QList<bookhub::gui::BookFormatEntry> formats);
+    void onLanguageSelectionChanged();
+    void onFormatSelectionChanged();
+    void onSourceSelectionChanged();
+    void onBackClicked();
+    void onNextOrDownloadClicked();
+    void onCancelDownloadClicked();
+    void onOpenFileClicked();
+    void onDownloadReadyRead();
+    void onDownloadProgress(qint64 received, qint64 total);
+    void onDownloadFinished();
+
+private:
+    void buildUi();
+    void resetState();
+    void updateStepUi();
+    void populateLanguageList();
+    void populateFormatList();
+    void populateSourceList();
+    void requestFormatsForSelectedLanguage();
+    bool beginDownload();
+    QString suggestedFilePath() const;
+    QString sanitizeFileName(const QString &name) const;
+    void showErrorState(const QString &message);
+    void setLibraryStatus(const QString &status);
+    BookSourceEntry selectedSource() const;
+
+    friend class ::bookhub::gui::DownloadFlowDialogTest;
+
+    LibraryService      *m_libraryService{};
+    BookDetailsService  *m_detailsService{};
+    QNetworkAccessManager *m_network{};
+    QNetworkReply       *m_reply{};
+    QSaveFile           *m_outputFile{};
+
+    QString m_bookId;
+    QString m_bookTitle;
+    int     m_libraryItemId{0};
+    QList<BookEditionEntry> m_editions;
+    QList<BookFormatEntry>  m_formats;
+    bool    m_hasLanguageStep{false};
+
+    quint64 m_pendingDetailsId{0};
+    quint64 m_pendingFormatsId{0};
+
+    int     m_currentStep{0}; // 0=language, 1=format, 2=source
+
+    QString m_targetFilePath;
+    QString m_lastError;
+
+    QLabel      *m_titleLabel{};
+    QLabel      *m_stepLabel{};
+    QListWidget *m_languageList{};
+    QListWidget *m_formatList{};
+    QListWidget *m_sourceList{};
+    QPushButton *m_backBtn{};
+    QPushButton *m_nextBtn{};
+
+    QWidget      *m_stepsContainer{};
+    QWidget      *m_progressContainer{};
+    QProgressBar *m_progressBar{};
+    QLabel       *m_progressText{};
+    QLabel       *m_progressPathLabel{};
+    QLabel       *m_resultLabel{};
+    QPushButton  *m_cancelBtn{};
+    QPushButton  *m_openFileBtn{};
+};
+
+} // namespace bookhub::gui

--- a/src/gui/dialogs/download_flow_dialog.h
+++ b/src/gui/dialogs/download_flow_dialog.h
@@ -78,7 +78,6 @@ private:
     int     m_currentStep{0}; // 0=language, 1=format, 2=source
 
     QString m_targetFilePath;
-    QString m_lastError;
 
     QLabel      *m_titleLabel{};
     QLabel      *m_stepLabel{};

--- a/src/gui/dialogs/download_flow_dialog.h
+++ b/src/gui/dialogs/download_flow_dialog.h
@@ -28,7 +28,7 @@ public:
     void startForBook(const QString &bookId);
 
 private slots:
-    void onDetailsCompleted(quint64 requestId, bookhub::gui::BookDetails details);
+    void onDetailsCompleted(quint64 requestId, const bookhub::gui::BookDetails &details);
     void onFormatsCompleted(quint64 requestId,
                             QList<bookhub::gui::BookFormatEntry> formats);
     void onLanguageSelectionChanged();

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -1,4 +1,5 @@
 #include "main_window.h"
+#include "dialogs/download_flow_dialog.h"
 #include "panels/book_details_panel.h"
 #include "query_worker.h"
 #include "screens/explore_screen.h"
@@ -108,6 +109,10 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
 
   connect(m_bookDetailsPanel, &BookDetailsPanel::dismissed,
           this, &MainWindow::onBookDetailsDismissed);
+  connect(m_bookDetailsPanel, &BookDetailsPanel::downloadRequested,
+          this, &MainWindow::onDownloadRequested);
+
+  m_downloadDialog = new DownloadFlowDialog(m_libraryService, m_queryWorker, this);
 
   // Status bar
   buildStatusBar();
@@ -253,6 +258,10 @@ void MainWindow::onBookDetailsRequested(const QString &bookId) {
 
 void MainWindow::onBookDetailsDismissed() {
   m_bookDetailsPanel->hide();
+}
+
+void MainWindow::onDownloadRequested(const QString &bookId) {
+  m_downloadDialog->startForBook(bookId);
 }
 
 } // namespace bookhub::gui

--- a/src/gui/main_window.h
+++ b/src/gui/main_window.h
@@ -12,6 +12,7 @@ class QThread;
 namespace bookhub::gui {
 
 class BookDetailsPanel;
+class DownloadFlowDialog;
 class ExploreScreen;
 class LibraryScreen;
 class LibraryService;
@@ -46,6 +47,7 @@ private slots:
     void onLibraryExploreRequested();
     void onBookDetailsRequested(const QString &bookId);
     void onBookDetailsDismissed();
+    void onDownloadRequested(const QString &bookId);
 
 private:
     friend class ::MainWindowTest;
@@ -66,6 +68,7 @@ private:
     SearchScreen      *m_searchScreen{};
     ExploreScreen     *m_exploreScreen{};
     BookDetailsPanel  *m_bookDetailsPanel{};
+    DownloadFlowDialog *m_downloadDialog{};
 
     // Status bar widgets
     QLabel *m_statusLabel{};

--- a/src/gui/panels/book_details_panel.cpp
+++ b/src/gui/panels/book_details_panel.cpp
@@ -398,7 +398,7 @@ void BookDetailsPanel::buildUi()
 
     m_downloadBtn = new QPushButton(QStringLiteral("↓ Download"), secondaryRow);
     m_downloadBtn->setStyleSheet(secondaryStyle);
-    m_downloadBtn->setToolTip(QStringLiteral("Download — coming soon"));
+    m_downloadBtn->setToolTip(QStringLiteral("Download this book"));
     m_downloadBtn->setEnabled(false); // Task 11
     connect(m_downloadBtn, &QPushButton::clicked, this,
             [this] { emit downloadRequested(m_currentBookId); });
@@ -479,6 +479,7 @@ void BookDetailsPanel::populateDetails(const BookDetails &details)
     }
 
     setLibraryButtonState(m_inLibrary);
+    m_downloadBtn->setEnabled(false);
 
     // Clear formats; they'll be loaded by the requestFormatsForEdition call
     // that follows immediately in onDetailsCompleted.
@@ -495,6 +496,7 @@ void BookDetailsPanel::populateFormats(const QList<BookFormatEntry> &formats)
     clearFormatsSection();
 
     if (formats.isEmpty()) {
+        m_downloadBtn->setEnabled(false);
         auto *noFmt = new QLabel(
             QStringLiteral("No downloadable formats available yet."),
             m_formatsWidget);
@@ -504,6 +506,8 @@ void BookDetailsPanel::populateFormats(const QList<BookFormatEntry> &formats)
         m_formatsLayout->addWidget(noFmt);
         return;
     }
+
+    m_downloadBtn->setEnabled(true);
 
     for (const auto &fmt : formats) {
         auto *row       = new QWidget(m_formatsWidget);

--- a/src/gui/panels/book_details_panel.cpp
+++ b/src/gui/panels/book_details_panel.cpp
@@ -57,7 +57,7 @@ void BookDetailsPanel::loadBook(const QString &bookId)
 // Private slots
 // ---------------------------------------------------------------------------
 
-void BookDetailsPanel::onDetailsCompleted(quint64 requestId, BookDetails details)
+void BookDetailsPanel::onDetailsCompleted(quint64 requestId, const BookDetails &details)
 {
     if (requestId != m_pendingDetailsId)
         return;
@@ -74,7 +74,7 @@ void BookDetailsPanel::onDetailsCompleted(quint64 requestId, BookDetails details
 }
 
 void BookDetailsPanel::onFormatsCompleted(quint64 requestId,
-                                          QList<BookFormatEntry> formats)
+                                          const QList<BookFormatEntry> &formats)
 {
     if (requestId != m_pendingFormatsId)
         return;
@@ -104,7 +104,7 @@ void BookDetailsPanel::onRemoveFromLibraryClicked()
     m_libraryService->requestRemoveBook(m_libraryItemId, m_currentBookId);
 }
 
-void BookDetailsPanel::onAddBookCompleted(quint64 requestId, QString /*bookId*/,
+void BookDetailsPanel::onAddBookCompleted(quint64 requestId, const QString &/*bookId*/,
                                           bool success, int newId)
 {
     if (requestId != m_pendingAddId)
@@ -117,7 +117,7 @@ void BookDetailsPanel::onAddBookCompleted(quint64 requestId, QString /*bookId*/,
     setLibraryButtonState(m_inLibrary);
 }
 
-void BookDetailsPanel::onRemoveBookCompleted(quint64 requestId, QString /*bookId*/, bool success)
+void BookDetailsPanel::onRemoveBookCompleted(quint64 requestId, const QString &/*bookId*/, bool success)
 {
     if (requestId != m_pendingRemoveId)
         return;
@@ -454,7 +454,7 @@ void BookDetailsPanel::populateDetails(const BookDetails &details)
             m_langCombo->addItem(ed.language);
     }
 
-    const int edCount   = details.editions.size();
+    const qsizetype edCount = details.editions.size();
     const bool multiLang = edCount > 1;
     m_langCombo->setVisible(multiLang);
     m_singleLangLabel->setVisible(!multiLang && edCount == 1);

--- a/src/gui/panels/book_details_panel.h
+++ b/src/gui/panels/book_details_panel.h
@@ -48,14 +48,14 @@ signals:
     void audiobookRequested(const QString &bookId);
 
 private slots:
-    void onDetailsCompleted(quint64 requestId, bookhub::gui::BookDetails details);
+    void onDetailsCompleted(quint64 requestId, const bookhub::gui::BookDetails &details);
     void onFormatsCompleted(quint64 requestId,
-                            QList<bookhub::gui::BookFormatEntry> formats);
+                            const QList<bookhub::gui::BookFormatEntry> &formats);
     void onLanguageChanged(int index);
     void onAddToLibraryClicked();
     void onRemoveFromLibraryClicked();
-    void onAddBookCompleted(quint64 requestId, QString bookId, bool success, int newId);
-    void onRemoveBookCompleted(quint64 requestId, QString bookId, bool success);
+    void onAddBookCompleted(quint64 requestId, const QString &bookId, bool success, int newId);
+    void onRemoveBookCompleted(quint64 requestId, const QString &bookId, bool success);
     void onToggleSummary();
 
 private:

--- a/src/gui/query_worker.cpp
+++ b/src/gui/query_worker.cpp
@@ -9,6 +9,8 @@
 #include <QSqlError>
 #include <QDebug>
 
+#include <utility>
+
 namespace bookhub::gui {
 
 QueryWorker::QueryWorker(QObject *parent)
@@ -42,14 +44,14 @@ void QueryWorker::onThreadFinished()
 // Search handlers
 // ---------------------------------------------------------------------------
 
-void QueryWorker::handleSearchRequest(quint64 requestId, SearchParams params,
+void QueryWorker::handleSearchRequest(quint64 requestId, const SearchParams &params,
                                        int offset, int limit)
 {
     emit searchCompleted(requestId,
         internal::runSearch(params, offset, limit, conn()));
 }
 
-void QueryWorker::handleCountRequest(quint64 requestId, SearchParams params)
+void QueryWorker::handleCountRequest(quint64 requestId, const SearchParams &params)
 {
     emit countCompleted(requestId,
         internal::runCount(params, conn()));
@@ -77,13 +79,13 @@ void QueryWorker::handleGenresRequest(quint64 requestId)
 // Library handlers
 // ---------------------------------------------------------------------------
 
-void QueryWorker::handleFetchItemsRequest(quint64 requestId, QString sortColumn)
+void QueryWorker::handleFetchItemsRequest(quint64 requestId, const QString &sortColumn)
 {
     emit fetchItemsCompleted(requestId,
         internal::fetchItems(sortColumn, conn()));
 }
 
-void QueryWorker::handleAddBookRequest(quint64 requestId, QString bookId, int editionId)
+void QueryWorker::handleAddBookRequest(quint64 requestId, const QString &bookId, int editionId)
 {
     const int newId = internal::addBook(bookId, editionId, conn());
     emit addBookCompleted(requestId, bookId, newId > 0, newId);
@@ -92,17 +94,17 @@ void QueryWorker::handleAddBookRequest(quint64 requestId, QString bookId, int ed
 void QueryWorker::handleRemoveBookRequest(quint64 requestId, int libraryItemId, QString bookId)
 {
     const bool ok = internal::removeBook(libraryItemId, conn());
-    emit removeBookCompleted(requestId, bookId, ok);
+    emit removeBookCompleted(requestId, std::move(bookId), ok);
 }
 
-void QueryWorker::handleRemoveBookByBookIdRequest(quint64 requestId, QString bookId)
+void QueryWorker::handleRemoveBookByBookIdRequest(quint64 requestId, const QString &bookId)
 {
     const bool ok = internal::removeBookByBookId(bookId, conn());
     emit removeBookCompleted(requestId, bookId, ok);
 }
 
 void QueryWorker::handleUpdateStatusRequest(quint64 requestId, int libraryItemId,
-                                             QString status)
+                                             const QString &status)
 {
     emit updateStatusCompleted(requestId,
         internal::updateStatus(libraryItemId, status, conn()));
@@ -130,7 +132,7 @@ void QueryWorker::handleCategoriesRequest(quint64 requestId)
         internal::fetchCategories(conn()));
 }
 
-void QueryWorker::handleBooksForGenreRequest(quint64 requestId, QString genre,
+void QueryWorker::handleBooksForGenreRequest(quint64 requestId, const QString &genre,
                                               int offset, int limit)
 {
     emit booksForGenreCompleted(requestId,
@@ -141,7 +143,7 @@ void QueryWorker::handleBooksForGenreRequest(quint64 requestId, QString genre,
 // Book details handlers
 // ---------------------------------------------------------------------------
 
-void QueryWorker::handleBookDetailsRequest(quint64 requestId, QString bookId)
+void QueryWorker::handleBookDetailsRequest(quint64 requestId, const QString &bookId)
 {
     emit bookDetailsCompleted(requestId,
         internal::fetchBookDetails(bookId, conn()));

--- a/src/gui/query_worker.h
+++ b/src/gui/query_worker.h
@@ -33,28 +33,30 @@ public slots:
     virtual void onThreadFinished();
 
     // Search
-    virtual void handleSearchRequest(quint64 requestId, bookhub::gui::SearchParams params,
+    virtual void handleSearchRequest(quint64 requestId, const bookhub::gui::SearchParams &params,
                                      int offset, int limit);
-    virtual void handleCountRequest(quint64 requestId, bookhub::gui::SearchParams params);
+    virtual void handleCountRequest(quint64 requestId, const bookhub::gui::SearchParams &params);
     virtual void handleLanguagesRequest(quint64 requestId);
     virtual void handleSourcesRequest(quint64 requestId);
     virtual void handleGenresRequest(quint64 requestId);
 
     // Library
-    virtual void handleFetchItemsRequest(quint64 requestId, QString sortColumn);
-    virtual void handleAddBookRequest(quint64 requestId, QString bookId, int editionId);
+    virtual void handleFetchItemsRequest(quint64 requestId, const QString &sortColumn);
+    virtual void handleAddBookRequest(quint64 requestId, const QString &bookId, int editionId);
     virtual void handleRemoveBookRequest(quint64 requestId, int libraryItemId, QString bookId);
-    virtual void handleRemoveBookByBookIdRequest(quint64 requestId, QString bookId);
-    virtual void handleUpdateStatusRequest(quint64 requestId, int libraryItemId, QString status);
+    virtual void handleRemoveBookByBookIdRequest(quint64 requestId, const QString &bookId);
+    virtual void handleUpdateStatusRequest(quint64 requestId, int libraryItemId,
+                                           const QString &status);
 
     // Explore
     virtual void handleTrendingRequest(quint64 requestId);
     virtual void handleNewArrivalsRequest(quint64 requestId);
     virtual void handleCategoriesRequest(quint64 requestId);
-    virtual void handleBooksForGenreRequest(quint64 requestId, QString genre, int offset, int limit);
+    virtual void handleBooksForGenreRequest(quint64 requestId, const QString &genre,
+                                            int offset, int limit);
 
     // Book details
-    virtual void handleBookDetailsRequest(quint64 requestId, QString bookId);
+    virtual void handleBookDetailsRequest(quint64 requestId, const QString &bookId);
     virtual void handleFormatsForEditionRequest(quint64 requestId, int editionId);
 
 signals:

--- a/src/gui/screens/explore_screen.cpp
+++ b/src/gui/screens/explore_screen.cpp
@@ -348,7 +348,7 @@ void ExploreScreen::loadTopLevelData()
 // ---------------------------------------------------------------------------
 
 void ExploreScreen::onTrendingCompleted(quint64 requestId,
-                                         QList<ExploreBook> books)
+                                         const QList<ExploreBook> &books)
 {
     if (requestId < m_pendingTrendingId)
         return;
@@ -360,7 +360,7 @@ void ExploreScreen::onTrendingCompleted(quint64 requestId,
 }
 
 void ExploreScreen::onNewArrivalsCompleted(quint64 requestId,
-                                            QList<ExploreBook> books)
+                                            const QList<ExploreBook> &books)
 {
     if (requestId < m_pendingNewArrivalsId)
         return;
@@ -372,7 +372,7 @@ void ExploreScreen::onNewArrivalsCompleted(quint64 requestId,
 }
 
 void ExploreScreen::onCategoriesCompleted(quint64 requestId,
-                                           QList<ExploreCategory> categories)
+                                           const QList<ExploreCategory> &categories)
 {
     if (requestId < m_pendingCategoriesId)
         return;
@@ -384,7 +384,7 @@ void ExploreScreen::onCategoriesCompleted(quint64 requestId,
 }
 
 void ExploreScreen::onBooksForGenreCompleted(quint64 requestId,
-                                              QList<ExploreBook> books)
+                                              const QList<ExploreBook> &books)
 {
     if (requestId < m_pendingGenreId)
         return;
@@ -413,7 +413,7 @@ void ExploreScreen::onBooksForGenreCompleted(quint64 requestId,
                                             absoluteIdx % kGridColumns);
     }
 
-    m_genreOffset = offset + books.size();
+    m_genreOffset = offset + static_cast<int>(books.size());
     m_loadMoreBtn->setVisible(books.size() == kGenrePageSize);
     m_loadMoreBtn->setEnabled(true);
 }

--- a/src/gui/screens/explore_screen.h
+++ b/src/gui/screens/explore_screen.h
@@ -40,12 +40,12 @@ private slots:
     void onLoadMore();
 
     // Async result slots
-    void onTrendingCompleted(quint64 requestId, QList<bookhub::gui::ExploreBook> books);
-    void onNewArrivalsCompleted(quint64 requestId, QList<bookhub::gui::ExploreBook> books);
+    void onTrendingCompleted(quint64 requestId, const QList<bookhub::gui::ExploreBook> &books);
+    void onNewArrivalsCompleted(quint64 requestId, const QList<bookhub::gui::ExploreBook> &books);
     void onCategoriesCompleted(quint64 requestId,
-                               QList<bookhub::gui::ExploreCategory> categories);
+                               const QList<bookhub::gui::ExploreCategory> &categories);
     void onBooksForGenreCompleted(quint64 requestId,
-                                  QList<bookhub::gui::ExploreBook> books);
+                                  const QList<bookhub::gui::ExploreBook> &books);
 
 private:
     // Page builders

--- a/src/gui/screens/library_screen.cpp
+++ b/src/gui/screens/library_screen.cpp
@@ -222,13 +222,13 @@ void LibraryScreen::reload()
     m_pendingFetchId = m_service->requestFetchItems(col);
 }
 
-void LibraryScreen::onFetchItemsCompleted(quint64 requestId, QList<LibraryItem> items)
+void LibraryScreen::onFetchItemsCompleted(quint64 requestId, const QList<LibraryItem> &items)
 {
     if (requestId < m_pendingFetchId)
         return; // stale response — a newer reload() is already in flight
 
     populateModel(items);
-    updateCountLabel(items.size());
+    updateCountLabel(static_cast<int>(items.size()));
     m_stack->setCurrentIndex(items.isEmpty() ? 1 : 0);
 }
 

--- a/src/gui/screens/library_screen.h
+++ b/src/gui/screens/library_screen.h
@@ -50,7 +50,7 @@ private slots:
     void onDownloadRequested(int libraryItemId, const QString &bookId);
     void onAudiobookRequested(int libraryItemId, const QString &bookId);
     void onRemoveRequested(int libraryItemId, const QString &bookId);
-    void onFetchItemsCompleted(quint64 requestId, QList<bookhub::gui::LibraryItem> items);
+    void onFetchItemsCompleted(quint64 requestId, const QList<bookhub::gui::LibraryItem> &items);
 
 private:
     void init(LibraryService *service);

--- a/src/gui/screens/search_screen.cpp
+++ b/src/gui/screens/search_screen.cpp
@@ -659,7 +659,7 @@ void SearchScreen::onCountCompleted(quint64 requestId, int count)
     m_service->requestSearch(m_pendingSearchParams, 0, kPageSize);
 }
 
-void SearchScreen::onSearchCompleted(quint64 requestId, QList<SearchResult> results)
+void SearchScreen::onSearchCompleted(quint64 requestId, const QList<SearchResult> &results)
 {
     if (requestId == m_pendingSearchId) {
         populateModel(results, false);
@@ -669,7 +669,7 @@ void SearchScreen::onSearchCompleted(quint64 requestId, QList<SearchResult> resu
             m_loadMoreBtn->setVisible(false);
         } else {
             setResultsState(1);
-            m_currentOffset = results.size();
+            m_currentOffset = static_cast<int>(results.size());
             m_loadMoreBtn->setVisible(m_currentOffset < m_totalCount);
             m_loadMoreBtn->setEnabled(true);
         }
@@ -681,7 +681,7 @@ void SearchScreen::onSearchCompleted(quint64 requestId, QList<SearchResult> resu
     }
 }
 
-void SearchScreen::onLoadMoreCompleted(quint64 requestId, QList<SearchResult> results)
+void SearchScreen::onLoadMoreCompleted(quint64 requestId, const QList<SearchResult> &results)
 {
     if (requestId < m_pendingLoadMoreId)
         return;
@@ -690,7 +690,7 @@ void SearchScreen::onLoadMoreCompleted(quint64 requestId, QList<SearchResult> re
         return;
 
     populateModel(results, true);
-    m_currentOffset += results.size();
+    m_currentOffset += static_cast<int>(results.size());
     m_loadMoreBtn->setVisible(m_currentOffset < m_totalCount);
     m_loadMoreBtn->setEnabled(true);
 }
@@ -712,7 +712,7 @@ void SearchScreen::onRemoveFromLibrary(const QString &bookId)
     m_libraryService->requestRemoveBookByBookId(bookId);
 }
 
-void SearchScreen::onAddBookCompleted(quint64 /*requestId*/, QString bookId,
+void SearchScreen::onAddBookCompleted(quint64 /*requestId*/, const QString &bookId,
                                        bool success, int /*newId*/)
 {
     if (!success)
@@ -727,7 +727,7 @@ void SearchScreen::onAddBookCompleted(quint64 /*requestId*/, QString bookId,
     }
 }
 
-void SearchScreen::onRemoveBookCompleted(quint64 /*requestId*/, QString bookId, bool success)
+void SearchScreen::onRemoveBookCompleted(quint64 /*requestId*/, const QString &bookId, bool success)
 {
     if (!success)
         return;
@@ -830,7 +830,7 @@ void SearchScreen::onGenresCompleted(quint64 /*requestId*/, QStringList genres)
         m_genreList->setFixedHeight(kGenreCollapsed * rowH);
 }
 
-void SearchScreen::onLanguagesCompleted(quint64 /*requestId*/, QStringList languages)
+void SearchScreen::onLanguagesCompleted(quint64 /*requestId*/, const QStringList &languages)
 {
     const QSignalBlocker blocker(m_langList);
     m_langList->clear();
@@ -842,7 +842,7 @@ void SearchScreen::onLanguagesCompleted(quint64 /*requestId*/, QStringList langu
     }
 }
 
-void SearchScreen::onSourcesCompleted(quint64 /*requestId*/, QStringList sources)
+void SearchScreen::onSourcesCompleted(quint64 /*requestId*/, const QStringList &sources)
 {
     const QSignalBlocker blocker(m_srcList);
     m_srcList->clear();

--- a/src/gui/screens/search_screen.cpp
+++ b/src/gui/screens/search_screen.cpp
@@ -811,7 +811,7 @@ void SearchScreen::onShowMoreGenres()
 // Filter population result slots
 // ---------------------------------------------------------------------------
 
-void SearchScreen::onGenresCompleted(quint64 /*requestId*/, QStringList genres)
+void SearchScreen::onGenresCompleted(quint64 /*requestId*/, const QStringList &genres)
 {
     const QSignalBlocker blocker(m_genreList);
     m_genreList->clear();

--- a/src/gui/screens/search_screen.h
+++ b/src/gui/screens/search_screen.h
@@ -66,7 +66,7 @@ private slots:
     void onRemoveBookCompleted(quint64 requestId, const QString &bookId, bool success);
     void onLanguagesCompleted(quint64 requestId, const QStringList &languages);
     void onSourcesCompleted(quint64 requestId, const QStringList &sources);
-    void onGenresCompleted(quint64 requestId, QStringList genres);
+    void onGenresCompleted(quint64 requestId, const QStringList &genres);
 
 private:
     void init(QueryWorker *worker);

--- a/src/gui/screens/search_screen.h
+++ b/src/gui/screens/search_screen.h
@@ -60,12 +60,12 @@ private slots:
 
     // Async result slots
     void onCountCompleted(quint64 requestId, int count);
-    void onSearchCompleted(quint64 requestId, QList<bookhub::gui::SearchResult> results);
-    void onLoadMoreCompleted(quint64 requestId, QList<bookhub::gui::SearchResult> results);
-    void onAddBookCompleted(quint64 requestId, QString bookId, bool success, int newId);
-    void onRemoveBookCompleted(quint64 requestId, QString bookId, bool success);
-    void onLanguagesCompleted(quint64 requestId, QStringList languages);
-    void onSourcesCompleted(quint64 requestId, QStringList sources);
+    void onSearchCompleted(quint64 requestId, const QList<bookhub::gui::SearchResult> &results);
+    void onLoadMoreCompleted(quint64 requestId, const QList<bookhub::gui::SearchResult> &results);
+    void onAddBookCompleted(quint64 requestId, const QString &bookId, bool success, int newId);
+    void onRemoveBookCompleted(quint64 requestId, const QString &bookId, bool success);
+    void onLanguagesCompleted(quint64 requestId, const QStringList &languages);
+    void onSourcesCompleted(quint64 requestId, const QStringList &sources);
     void onGenresCompleted(quint64 requestId, QStringList genres);
 
 private:

--- a/src/gui/services/book_details_service.cpp
+++ b/src/gui/services/book_details_service.cpp
@@ -22,11 +22,11 @@ void BookDetailsService::connectToWorker(QueryWorker *worker)
 
     connect(worker, &QueryWorker::bookDetailsCompleted, this,
             [this](quint64 id, BookDetails details) {
-                emit detailsCompleted(id, details);
+                emit detailsCompleted(id, std::move(details));
             });
     connect(worker, &QueryWorker::formatsForEditionCompleted, this,
             [this](quint64 id, QList<BookFormatEntry> formats) {
-                emit formatsCompleted(id, formats);
+                emit formatsCompleted(id, std::move(formats));
             });
 }
 

--- a/src/gui/services/explore_service.cpp
+++ b/src/gui/services/explore_service.cpp
@@ -27,25 +27,25 @@ void ExploreService::connectToWorker(QueryWorker *worker)
             [this](quint64 id, QList<ExploreBook> books) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit trendingCompleted(id, books);
+                emit trendingCompleted(id, std::move(books));
             });
     connect(worker, &QueryWorker::newArrivalsCompleted, this,
             [this](quint64 id, QList<ExploreBook> books) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit newArrivalsCompleted(id, books);
+                emit newArrivalsCompleted(id, std::move(books));
             });
     connect(worker, &QueryWorker::categoriesCompleted, this,
             [this](quint64 id, QList<ExploreCategory> cats) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit categoriesCompleted(id, cats);
+                emit categoriesCompleted(id, std::move(cats));
             });
     connect(worker, &QueryWorker::booksForGenreCompleted, this,
             [this](quint64 id, QList<ExploreBook> books) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit booksForGenreCompleted(id, books);
+                emit booksForGenreCompleted(id, std::move(books));
             });
 }
 

--- a/src/gui/services/library_service.cpp
+++ b/src/gui/services/library_service.cpp
@@ -29,13 +29,13 @@ void LibraryService::connectToWorker(QueryWorker *worker)
             [this](quint64 id, QList<LibraryItem> items) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit fetchItemsCompleted(id, items);
+                emit fetchItemsCompleted(id, std::move(items));
             });
     connect(worker, &QueryWorker::addBookCompleted, this,
             [this](quint64 id, QString bookId, bool success, int newId) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit addBookCompleted(id, bookId, success, newId);
+                emit addBookCompleted(id, std::move(bookId), success, newId);
                 if (success)
                     emit libraryChanged();
             });
@@ -43,7 +43,7 @@ void LibraryService::connectToWorker(QueryWorker *worker)
             [this](quint64 id, QString bookId, bool success) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit removeBookCompleted(id, bookId, success);
+                emit removeBookCompleted(id, std::move(bookId), success);
                 if (success)
                     emit libraryChanged();
             });

--- a/src/gui/services/search_service.cpp
+++ b/src/gui/services/search_service.cpp
@@ -32,7 +32,7 @@ void SearchService::connectToWorker(QueryWorker *worker)
             [this](quint64 id, QList<SearchResult> results) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit searchCompleted(id, results);
+                emit searchCompleted(id, std::move(results));
             });
     connect(worker, &QueryWorker::countCompleted, this,
             [this](quint64 id, int count) {
@@ -44,19 +44,19 @@ void SearchService::connectToWorker(QueryWorker *worker)
             [this](quint64 id, QStringList langs) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit languagesCompleted(id, langs);
+                emit languagesCompleted(id, std::move(langs));
             });
     connect(worker, &QueryWorker::sourcesCompleted, this,
             [this](quint64 id, QStringList srcs) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit sourcesCompleted(id, srcs);
+                emit sourcesCompleted(id, std::move(srcs));
             });
     connect(worker, &QueryWorker::genresCompleted, this,
             [this](quint64 id, QStringList genres) {
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
-                emit genresCompleted(id, genres);
+                emit genresCompleted(id, std::move(genres));
             });
 }
 

--- a/tests/gui/test_download_flow_dialog.cpp
+++ b/tests/gui/test_download_flow_dialog.cpp
@@ -51,7 +51,7 @@ void DownloadFlowDialogTest::singleLanguage_startsAtFormatStep()
     dialog.onDetailsCompleted(7, details);
 
     QCOMPARE(dialog.m_currentStep, 1);
-    QCOMPARE(dialog.m_stepLabel->text(), QStringLiteral("Step 2 of 3: Format"));
+    QCOMPARE(dialog.m_stepLabel->text(), QStringLiteral("Step 1 of 2: Format"));
 }
 
 void DownloadFlowDialogTest::nextButton_requiresSelectionsPerStep()

--- a/tests/gui/test_download_flow_dialog.cpp
+++ b/tests/gui/test_download_flow_dialog.cpp
@@ -1,0 +1,117 @@
+#include <QtTest>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+
+#include "gui/dialogs/download_flow_dialog.h"
+#include "gui/services/library_service.h"
+#include "support/test_query_worker.h"
+
+namespace bookhub::gui {
+
+class DownloadFlowDialogTest : public QObject {
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+
+    void singleLanguage_startsAtFormatStep();
+    void nextButton_requiresSelectionsPerStep();
+    void formatSelection_populatesSources();
+
+private:
+    TestQueryWorker *m_worker{};
+    LibraryService  *m_libraryService{};
+};
+
+void DownloadFlowDialogTest::init()
+{
+    m_worker = new TestQueryWorker();
+    m_libraryService = new LibraryService();
+    m_libraryService->connectToWorker(m_worker);
+}
+
+void DownloadFlowDialogTest::cleanup()
+{
+    delete m_libraryService;
+    m_libraryService = nullptr;
+    delete m_worker;
+    m_worker = nullptr;
+}
+
+void DownloadFlowDialogTest::singleLanguage_startsAtFormatStep()
+{
+    DownloadFlowDialog dialog(m_libraryService, m_worker);
+    dialog.m_pendingDetailsId = 7;
+
+    BookDetails details;
+    details.title = QStringLiteral("Pride and Prejudice");
+    details.editions.append({11, QStringLiteral("en")});
+    dialog.onDetailsCompleted(7, details);
+
+    QCOMPARE(dialog.m_currentStep, 1);
+    QCOMPARE(dialog.m_stepLabel->text(), QStringLiteral("Step 2 of 3: Format"));
+}
+
+void DownloadFlowDialogTest::nextButton_requiresSelectionsPerStep()
+{
+    DownloadFlowDialog dialog(m_libraryService, m_worker);
+    dialog.m_pendingDetailsId = 9;
+
+    BookDetails details;
+    details.title = QStringLiteral("Multilingual");
+    details.editions.append({21, QStringLiteral("en")});
+    details.editions.append({22, QStringLiteral("fr")});
+    dialog.onDetailsCompleted(9, details);
+
+    QCOMPARE(dialog.m_currentStep, 0);
+    QVERIFY(dialog.m_nextBtn->isEnabled());
+
+    dialog.onNextOrDownloadClicked();
+    QCOMPARE(dialog.m_currentStep, 1);
+    QVERIFY(!dialog.m_nextBtn->isEnabled());
+
+    QList<BookFormatEntry> formats;
+    BookFormatEntry epub;
+    epub.formatType = QStringLiteral("epub");
+    formats.append(epub);
+    dialog.m_pendingFormatsId = 12;
+    dialog.onFormatsCompleted(12, formats);
+
+    QVERIFY(dialog.m_nextBtn->isEnabled());
+}
+
+void DownloadFlowDialogTest::formatSelection_populatesSources()
+{
+    DownloadFlowDialog dialog(m_libraryService, m_worker);
+    dialog.m_currentStep = 1;
+
+    QList<BookFormatEntry> formats;
+
+    BookFormatEntry epub;
+    epub.formatType = QStringLiteral("epub");
+    epub.sources.append({QStringLiteral("Gutenberg"), QStringLiteral("https://gutenberg.org/epub")});
+    epub.sources.append({QStringLiteral("Mirror"), QStringLiteral("https://mirror.org/epub")});
+
+    BookFormatEntry pdf;
+    pdf.formatType = QStringLiteral("pdf");
+    pdf.sources.append({QStringLiteral("Gutenberg"), QStringLiteral("https://gutenberg.org/pdf")});
+
+    formats.append(epub);
+    formats.append(pdf);
+    dialog.m_pendingFormatsId = 4;
+    dialog.onFormatsCompleted(4, formats);
+
+    dialog.m_formatList->setCurrentRow(1);
+    dialog.onFormatSelectionChanged();
+
+    QCOMPARE(dialog.m_sourceList->count(), 1);
+    QVERIFY(dialog.m_sourceList->item(0)->text().contains(QStringLiteral("Gutenberg")));
+}
+
+} // namespace bookhub::gui
+
+using DownloadFlowDialogTest = bookhub::gui::DownloadFlowDialogTest;
+QTEST_MAIN(DownloadFlowDialogTest)
+#include "test_download_flow_dialog.moc"

--- a/tests/gui/test_download_flow_dialog.cpp
+++ b/tests/gui/test_download_flow_dialog.cpp
@@ -20,6 +20,13 @@ private slots:
     void nextButton_requiresSelectionsPerStep();
     void formatSelection_populatesSources();
 
+    void backNavigation_decrementsStep();
+    void backNavigation_singleLanguage_clampedAtFormatStep();
+    void staleDetailsRequest_isIgnored();
+    void staleFormatsRequest_isIgnored();
+    void emptyEditions_showsErrorState();
+    void singleEdition_formatRequestedExactlyOnce();
+
 private:
     TestQueryWorker *m_worker{};
     LibraryService  *m_libraryService{};
@@ -108,6 +115,128 @@ void DownloadFlowDialogTest::formatSelection_populatesSources()
 
     QCOMPARE(dialog.m_sourceList->count(), 1);
     QVERIFY(dialog.m_sourceList->item(0)->text().contains(QStringLiteral("Gutenberg")));
+}
+
+void DownloadFlowDialogTest::backNavigation_decrementsStep()
+{
+    DownloadFlowDialog dialog(m_libraryService, m_worker);
+    dialog.m_pendingDetailsId = 1;
+
+    BookDetails details;
+    details.editions.append({1, QStringLiteral("en")});
+    details.editions.append({2, QStringLiteral("fr")});
+    dialog.onDetailsCompleted(1, details);
+    QCOMPARE(dialog.m_currentStep, 0); // language step
+
+    // back at minimum step is a no-op
+    dialog.onBackClicked();
+    QCOMPARE(dialog.m_currentStep, 0);
+    QVERIFY(dialog.m_backBtn->isHidden());
+
+    // advance to format step
+    dialog.onNextOrDownloadClicked();
+    QCOMPARE(dialog.m_currentStep, 1);
+    QVERIFY(!dialog.m_backBtn->isHidden());
+
+    // back returns to language step and hides the back button
+    dialog.onBackClicked();
+    QCOMPARE(dialog.m_currentStep, 0);
+    QVERIFY(dialog.m_backBtn->isHidden());
+}
+
+void DownloadFlowDialogTest::backNavigation_singleLanguage_clampedAtFormatStep()
+{
+    DownloadFlowDialog dialog(m_libraryService, m_worker);
+    dialog.m_pendingDetailsId = 2;
+
+    BookDetails details;
+    details.editions.append({1, QStringLiteral("en")});
+    dialog.onDetailsCompleted(2, details);
+    QCOMPARE(dialog.m_currentStep, 1); // starts at format step; no language step
+
+    // back at format step (minimum for single-language) is a no-op
+    dialog.onBackClicked();
+    QCOMPARE(dialog.m_currentStep, 1);
+
+    // inject a format with a source so we can reach the source step
+    QList<BookFormatEntry> formats;
+    BookFormatEntry epub;
+    epub.formatType = QStringLiteral("epub");
+    epub.sources.append({QStringLiteral("Gutenberg"), QStringLiteral("https://example.com/book.epub")});
+    formats.append(epub);
+    dialog.m_pendingFormatsId = 99;
+    dialog.onFormatsCompleted(99, formats);
+
+    dialog.onNextOrDownloadClicked();
+    QCOMPARE(dialog.m_currentStep, 2);
+
+    // back returns to format step
+    dialog.onBackClicked();
+    QCOMPARE(dialog.m_currentStep, 1);
+
+    // back at format step (minimum) is a no-op again
+    dialog.onBackClicked();
+    QCOMPARE(dialog.m_currentStep, 1);
+}
+
+void DownloadFlowDialogTest::staleDetailsRequest_isIgnored()
+{
+    DownloadFlowDialog dialog(m_libraryService, m_worker);
+    dialog.m_pendingDetailsId = 5;
+
+    BookDetails details;
+    details.editions.append({1, QStringLiteral("en")});
+    dialog.onDetailsCompleted(4, details); // wrong request ID
+
+    QVERIFY(dialog.m_editions.isEmpty());
+    QCOMPARE(dialog.m_currentStep, 0);
+}
+
+void DownloadFlowDialogTest::staleFormatsRequest_isIgnored()
+{
+    DownloadFlowDialog dialog(m_libraryService, m_worker);
+    dialog.m_pendingFormatsId = 7;
+
+    QList<BookFormatEntry> formats;
+    BookFormatEntry epub;
+    epub.formatType = QStringLiteral("epub");
+    formats.append(epub);
+    dialog.onFormatsCompleted(6, formats); // wrong request ID
+
+    QVERIFY(dialog.m_formats.isEmpty());
+}
+
+void DownloadFlowDialogTest::emptyEditions_showsErrorState()
+{
+    DownloadFlowDialog dialog(m_libraryService, m_worker);
+    dialog.m_pendingDetailsId = 3;
+
+    BookDetails details;
+    details.title = QStringLiteral("Empty Book");
+    // no editions — should trigger error state
+    dialog.onDetailsCompleted(3, details);
+
+    QVERIFY(dialog.m_stepsContainer->isHidden());
+    QVERIFY(!dialog.m_progressContainer->isHidden());
+    QCOMPARE(dialog.m_stepLabel->text(), QStringLiteral("Error"));
+    QVERIFY(!dialog.m_resultLabel->text().isEmpty());
+}
+
+void DownloadFlowDialogTest::singleEdition_formatRequestedExactlyOnce()
+{
+    DownloadFlowDialog dialog(m_libraryService, m_worker);
+    dialog.m_pendingDetailsId = 1;
+
+    const quint64 idBefore = dialog.m_detailsService->peekNextId();
+
+    BookDetails details;
+    details.editions.append({1, QStringLiteral("en")});
+    dialog.onDetailsCompleted(1, details);
+
+    // Regression guard: exactly one format request must fire for a single-edition book.
+    // Two would mean populateLanguageList's implicit trigger fired AND onDetailsCompleted
+    // issued a second explicit request — the double-request bug.
+    QCOMPARE(dialog.m_detailsService->peekNextId() - idBefore, quint64{1});
 }
 
 } // namespace bookhub::gui

--- a/tests/support/test_query_worker.h
+++ b/tests/support/test_query_worker.h
@@ -28,14 +28,14 @@ public slots:
     void onThreadStarted() override {}
     void onThreadFinished() override {}
 
-    void handleSearchRequest(quint64 requestId, bookhub::gui::SearchParams params,
+    void handleSearchRequest(quint64 requestId, const bookhub::gui::SearchParams &params,
                              int offset, int limit) override
     {
         emit searchCompleted(requestId,
             internal::runSearch(params, offset, limit, QSqlDatabase::defaultConnection));
     }
 
-    void handleCountRequest(quint64 requestId, bookhub::gui::SearchParams params) override
+    void handleCountRequest(quint64 requestId, const bookhub::gui::SearchParams &params) override
     {
         emit countCompleted(requestId,
             internal::runCount(params, QSqlDatabase::defaultConnection));
@@ -59,13 +59,13 @@ public slots:
             internal::fetchGenres(QSqlDatabase::defaultConnection));
     }
 
-    void handleFetchItemsRequest(quint64 requestId, QString sortColumn) override
+    void handleFetchItemsRequest(quint64 requestId, const QString &sortColumn) override
     {
         emit fetchItemsCompleted(requestId,
             internal::fetchItems(sortColumn, QSqlDatabase::defaultConnection));
     }
 
-    void handleAddBookRequest(quint64 requestId, QString bookId, int editionId) override
+    void handleAddBookRequest(quint64 requestId, const QString &bookId, int editionId) override
     {
         const int newId = internal::addBook(bookId, editionId, QSqlDatabase::defaultConnection);
         emit addBookCompleted(requestId, bookId, newId > 0, newId);
@@ -73,18 +73,18 @@ public slots:
 
     void handleRemoveBookRequest(quint64 requestId, int libraryItemId, QString bookId) override
     {
-        emit removeBookCompleted(requestId, bookId,
-            internal::removeBook(libraryItemId, QSqlDatabase::defaultConnection));
+        const bool ok = internal::removeBook(libraryItemId, QSqlDatabase::defaultConnection);
+        emit removeBookCompleted(requestId, std::move(bookId), ok);
     }
 
-    void handleRemoveBookByBookIdRequest(quint64 requestId, QString bookId) override
+    void handleRemoveBookByBookIdRequest(quint64 requestId, const QString &bookId) override
     {
         emit removeBookCompleted(requestId, bookId,
             internal::removeBookByBookId(bookId, QSqlDatabase::defaultConnection));
     }
 
     void handleUpdateStatusRequest(quint64 requestId, int libraryItemId,
-                                   QString status) override
+                                   const QString &status) override
     {
         emit updateStatusCompleted(requestId,
             internal::updateStatus(libraryItemId, status, QSqlDatabase::defaultConnection));
@@ -108,7 +108,7 @@ public slots:
             internal::fetchCategories(QSqlDatabase::defaultConnection));
     }
 
-    void handleBooksForGenreRequest(quint64 requestId, QString genre,
+    void handleBooksForGenreRequest(quint64 requestId, const QString &genre,
                                     int offset, int limit) override
     {
         emit booksForGenreCompleted(requestId,
@@ -116,7 +116,7 @@ public slots:
                                          QSqlDatabase::defaultConnection));
     }
 
-    void handleBookDetailsRequest(quint64 requestId, QString bookId) override
+    void handleBookDetailsRequest(quint64 requestId, const QString &bookId) override
     {
         emit bookDetailsCompleted(requestId,
             internal::fetchBookDetails(bookId, QSqlDatabase::defaultConnection));


### PR DESCRIPTION
## Summary
- implement `DownloadFlowDialog` for Task 11 with 3-step language/format/source selection launched from `BookDetailsPanel`
- wire dialog through `MainWindow`, enable Download button when formats exist, and add async HTTP download with `QSaveFile` + persisted last-used directory in `QSettings`
- improve source selection UX (source name labels), remove `QSaveFile` double ownership, and add `test_download_flow_dialog` coverage and CMake target

## Linked issues
- Closes #12
- Refs #36

## Test plan
- [x] `cmake --build . --parallel`
- [x] `ctest -R test_download_flow_dialog --output-on-failure`
- [x] `ctest -L sanity --output-on-failure`