### PR TITLE
feat: implement Task 12 — audiobook conversion flow (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ Project-specific slash commands live in `.claude/commands/`:
 
 ### Current Status
 
-Tasks 1–8 complete: project scaffolding, SQLite schema, single-executable build, background collector with Gutenberg adapter, application icon, Library screen, Search screen, Explore screen.
+Tasks 1–12, 16, 19 complete: project scaffolding, SQLite schema, single-executable build, background collector with Gutenberg adapter, application icon, Library screen, Search screen, Explore screen, BookDetailsPanel, add/remove from library, download flow, audiobook conversion flow (UI scaffold — TTS generation deferred to Task 13), UI polish, multiplatform support.
 
-Tasks 9–17 not started: Book Details screen, library management, download flow, audiobook/TTS conversion, additional source adapters, UI polish, and packaging.
+Task 15 in progress: source adapter extensibility refactor.
+
+Tasks 13–14, 17–18 not started: TTS integration, custom voice upload, packaging, and tooltip polish.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,9 @@ set(COLLECTOR_SOURCES
 )
 
 set(GUI_SOURCES
+    src/gui/dialogs/audiobook_flow_dialog.cpp
     src/gui/dialogs/download_flow_dialog.cpp
+    src/gui/dialogs/voice_upload_dialog.cpp
     src/gui/main_window.cpp
     src/gui/panels/book_details_panel.cpp
     src/gui/screens/explore_screen.cpp
@@ -40,11 +42,14 @@ set(GUI_SOURCES
     src/gui/services/explore_service.cpp
     src/gui/services/library_service.cpp
     src/gui/services/search_service.cpp
+    src/gui/services/tts_service.cpp
     src/gui/widgets/badge_label.cpp
     src/gui/widgets/book_card_delegate.cpp
     src/gui/widgets/empty_state_widget.cpp
+    src/gui/widgets/mini_audio_player_widget.cpp
     src/gui/widgets/search_result_delegate.cpp
     src/gui/widgets/step_indicator_widget.cpp
+    src/gui/widgets/voice_selector_widget.cpp
     src/gui/query_worker.cpp
 )
 
@@ -137,3 +142,8 @@ add_bookhub_test(test_step_indicator_widget
     tests/gui/test_step_indicator_widget.cpp
 )
 label_bookhub_test(test_step_indicator_widget sanity gui widgets)
+
+add_bookhub_test(test_audiobook_flow_dialog
+    tests/gui/test_audiobook_flow_dialog.cpp
+)
+label_bookhub_test(test_audiobook_flow_dialog sanity gui audiobook)

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -109,8 +109,8 @@ void AudiobookFlowDialog::buildUi()
     // Step 4: Preview
     QWidget *previewStep = new QWidget(this);
     QVBoxLayout *previewLayout = new QVBoxLayout(previewStep);
-    QLabel *previewLabel = new QLabel("Listening to: <voice name>", this);
-    previewLayout->addWidget(previewLabel);
+    m_previewVoiceLabel = new QLabel("Listening to: —", this);
+    previewLayout->addWidget(m_previewVoiceLabel);
     m_previewText = new QLabel(this);
     m_previewText->setWordWrap(true);
     m_previewText->setMaximumHeight(80);
@@ -254,10 +254,14 @@ void AudiobookFlowDialog::onVoiceSelectionChanged(int voiceId, const QString &vo
     m_selectedVoiceId = voiceId;
     m_selectedVoiceName = voiceName;
     m_previewVoiceBtn->setEnabled(voiceId >= 0);
+    m_previewVoiceLabel->setText(voiceId >= 0
+        ? QString("Listening to: %1").arg(voiceName)
+        : QStringLiteral("Listening to: —"));
 }
 
 void AudiobookFlowDialog::onVoiceUploadRequested()
 {
+    delete m_uploadDialog;
     m_uploadDialog = new VoiceUploadDialog(this);
     if (m_uploadDialog->exec() == QDialog::Accepted)
         populateVoiceList(); // refresh list after upload (DB insertion deferred to Phase 3)
@@ -309,7 +313,6 @@ void AudiobookFlowDialog::onGenerationComplete()
     disconnect(m_nextBtn, &QPushButton::clicked,
                this, &AudiobookFlowDialog::onNextOrGenerateClicked);
     connect(m_nextBtn, &QPushButton::clicked, this, &QDialog::accept);
-    setLibraryStatus(QStringLiteral("audiobook_ready"));
 }
 
 void AudiobookFlowDialog::onPreviewVoiceClicked()
@@ -324,7 +327,7 @@ void AudiobookFlowDialog::onOpenFileClicked()
 
 void AudiobookFlowDialog::onAddToLibraryClicked()
 {
-    setLibraryStatus(QStringLiteral("audiobook_ready"));
+    markAudiobookReady();
     accept();
 }
 
@@ -342,15 +345,19 @@ void AudiobookFlowDialog::populateLanguageList()
 void AudiobookFlowDialog::populateFormatList()
 {
     m_formatList->clear();
-    for (const auto &format : m_formats) {
-        QString label = format.formatType;
-        if (format.formatType == QLatin1String("epub"))
+    int epubIndex = -1;
+    for (int i = 0; i < m_formats.size(); ++i) {
+        QString label = m_formats[i].formatType;
+        if (m_formats[i].formatType == QLatin1String("epub")) {
             label += " (recommended)";
+            epubIndex = i;
+        }
         m_formatList->addItem(new QListWidgetItem(label));
     }
     if (!m_formats.isEmpty()) {
-        m_formatList->setCurrentRow(0);
-        m_selectedFormat = m_formats.first().formatType;
+        const int selectRow = (epubIndex >= 0) ? epubIndex : 0;
+        m_formatList->setCurrentRow(selectRow);
+        m_selectedFormat = m_formats[selectRow].formatType;
     }
 }
 
@@ -389,7 +396,7 @@ bool AudiobookFlowDialog::startGeneration()
     return true;
 }
 
-void AudiobookFlowDialog::setLibraryStatus(const QString &)
+void AudiobookFlowDialog::markAudiobookReady()
 {
     if (m_libraryItemId > 0 && m_libraryService)
         m_libraryService->requestSetAudiobookReady(m_bookId);

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -44,7 +44,7 @@ AudiobookFlowDialog::AudiobookFlowDialog(LibraryService *libraryService,
                 m_worker, &QueryWorker::handleListVoicesRequest);
 
         connect(m_worker,
-                QOverload<quint64, QList<VoiceEntry>>::of(&QueryWorker::listVoicesCompleted),
+                &QueryWorker::listVoicesCompleted,
                 this,
                 [this](quint64 requestId, const QList<VoiceEntry> &voices) {
                     if (requestId == m_pendingVoicesId && m_voiceSelector)
@@ -188,6 +188,7 @@ void AudiobookFlowDialog::startForBook(const QString &bookId)
 void AudiobookFlowDialog::resetState()
 {
     m_currentStep = 0;
+    m_hasLanguageStep = false;
     m_selectedLanguage.clear();
     m_selectedFormat.clear();
     m_selectedVoiceId = -1;
@@ -272,7 +273,7 @@ void AudiobookFlowDialog::onFormatSelectionChanged()
     if (!item)
         return;
 
-    m_selectedFormat = item->text().split(" (")[0]; // strip "(recommended)" suffix
+    m_selectedFormat = item->data(Qt::UserRole).toString();
     updateNextButtonEnabled();
 }
 
@@ -387,12 +388,15 @@ void AudiobookFlowDialog::populateFormatList()
     m_formatList->clear();
     int epubIndex = -1;
     for (int i = 0; i < m_formats.size(); ++i) {
-        QString label = m_formats[i].formatType;
-        if (m_formats[i].formatType == QLatin1String("epub")) {
+        const QString &type = m_formats[i].formatType;
+        QString label = type;
+        if (type == QLatin1String("epub")) {
             label += " (recommended)";
             epubIndex = i;
         }
-        m_formatList->addItem(new QListWidgetItem(label));
+        auto *item = new QListWidgetItem(label);
+        item->setData(Qt::UserRole, type);
+        m_formatList->addItem(item);
     }
     if (!m_formats.isEmpty()) {
         const int selectRow = (epubIndex >= 0) ? epubIndex : 0;
@@ -404,7 +408,7 @@ void AudiobookFlowDialog::populateFormatList()
 void AudiobookFlowDialog::populateVoiceList()
 {
     if (m_worker) {
-        m_pendingVoicesId = m_requestCounter.fetch_add(1);
+        m_pendingVoicesId = m_requestCounter++;
         emit listVoicesRequested(m_pendingVoicesId);
     }
 }

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -193,6 +193,9 @@ void AudiobookFlowDialog::resetState()
     m_selectedFormat.clear();
     m_selectedVoiceId = -1;
     m_selectedVoiceName.clear();
+    m_pendingDetailsId = 0;
+    m_pendingFormatsId = 0;
+    m_pendingVoicesId  = 0;
     m_languageList->clear();
     m_formatList->clear();
     m_voiceSelector->setVoices({});
@@ -228,7 +231,8 @@ void AudiobookFlowDialog::onDetailsCompleted(quint64 requestId,
     m_titleLabel->setText(QString("Convert to Audiobook — %1").arg(m_bookTitle));
 
     m_hasLanguageStep = m_editions.size() > 1;
-    populateLanguageList();
+    if (m_hasLanguageStep)
+        populateLanguageList();
 
     if (!m_hasLanguageStep && !m_editions.isEmpty()) {
         m_selectedLanguage = m_editions.first().language;
@@ -290,15 +294,14 @@ void AudiobookFlowDialog::onVoiceSelectionChanged(int voiceId, const QString &vo
 
 void AudiobookFlowDialog::onVoiceUploadRequested()
 {
-    delete m_uploadDialog;
-    m_uploadDialog = new VoiceUploadDialog(this);
-    if (m_uploadDialog->exec() == QDialog::Accepted) {
+    VoiceUploadDialog uploadDialog(this);
+    if (uploadDialog.exec() == QDialog::Accepted) {
         // Phase 3: insert into voices table and call populateVoiceList().
         // For now, acknowledge the submission so the user knows it was received.
         QMessageBox::information(this, "Voice Registered",
             QString("\"%1\" has been noted.\n\n"
                     "Custom voice cloning will be available in a future release.")
-                .arg(m_uploadDialog->voiceName()));
+                .arg(uploadDialog.voiceName()));
     }
 }
 

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -227,6 +227,9 @@ void AudiobookFlowDialog::onDetailsCompleted(quint64 requestId,
     if (!m_hasLanguageStep && !m_editions.isEmpty()) {
         m_selectedLanguage = m_editions.first().language;
         m_pendingFormatsId = m_detailsService->requestFormatsForEdition(m_editions.first().editionId);
+        // Skip the pointless single-language step and open directly on format selection.
+        m_currentStep = 1;
+        updateStepUi();
     }
 }
 
@@ -278,8 +281,14 @@ void AudiobookFlowDialog::onVoiceUploadRequested()
 {
     delete m_uploadDialog;
     m_uploadDialog = new VoiceUploadDialog(this);
-    if (m_uploadDialog->exec() == QDialog::Accepted)
-        populateVoiceList(); // refresh list after upload (DB insertion deferred to Phase 3)
+    if (m_uploadDialog->exec() == QDialog::Accepted) {
+        // Phase 3: insert into voices table and call populateVoiceList().
+        // For now, acknowledge the submission so the user knows it was received.
+        QMessageBox::information(this, "Voice Registered",
+            QString("\"%1\" has been noted.\n\n"
+                    "Custom voice cloning will be available in a future release.")
+                .arg(m_uploadDialog->voiceName()));
+    }
 }
 
 void AudiobookFlowDialog::onBackClicked()

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -18,6 +18,7 @@
 #include <QUrl>
 #include <QDir>
 #include <QDebug>
+#include <QDateTime>
 
 namespace bookhub::gui {
 
@@ -231,7 +232,7 @@ void AudiobookFlowDialog::onVoiceSelectionChanged(int voiceId, const QString &vo
     m_selectedVoiceName = voiceName;
 }
 
-void AudiobookFlowDialog::onPreviewRequested(int voiceId, const QString &voiceName)
+void AudiobookFlowDialog::onPreviewRequested([[maybe_unused]] int voiceId, const QString &voiceName)
 {
     // MVP: placeholder for voice preview generation
     // In Phase 3+, generate preview audio via TTS service
@@ -340,13 +341,21 @@ void AudiobookFlowDialog::populateFormatList()
 
 void AudiobookFlowDialog::populateVoiceList()
 {
-    // Load voices from database
-    QList<VoiceEntry> voices;
-    voices.append({1, "Classic Storyteller", true});
-    voices.append({2, "Warm Listener", true});
-    voices.append({3, "Crisp Narrator", true});
-    // In Phase 3+, also load custom voices from DB
-    m_voiceSelector->setVoices(voices);
+    // Request voices from database via query worker
+    if (m_worker) {
+        m_pendingVoicesId = reinterpret_cast<quint64>(this) ^ QDateTime::currentMSecsSinceEpoch();
+        // Use lambda to handle result without adding slot to Q_OBJECT
+        connect(m_worker,
+                QOverload<quint64, QList<VoiceEntry>>::of(&QueryWorker::listVoicesCompleted),
+                this,
+                [this](quint64 requestId, QList<VoiceEntry> voices) {
+                    if (requestId == m_pendingVoicesId && m_voiceSelector) {
+                        m_voiceSelector->setVoices(voices);
+                    }
+                },
+                Qt::UniqueConnection);
+        m_worker->handleListVoicesRequest(m_pendingVoicesId);
+    }
 }
 
 void AudiobookFlowDialog::updateStepUi()

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -47,8 +47,10 @@ AudiobookFlowDialog::AudiobookFlowDialog(LibraryService *libraryService,
                 &QueryWorker::listVoicesCompleted,
                 this,
                 [this](quint64 requestId, const QList<VoiceEntry> &voices) {
-                    if (requestId == m_pendingVoicesId && m_voiceSelector)
+                    if (requestId == m_pendingVoicesId && m_voiceSelector) {
                         m_voiceSelector->setVoices(voices);
+                        m_voicesLoaded = true;
+                    }
                 });
     }
 
@@ -196,6 +198,7 @@ void AudiobookFlowDialog::resetState()
     m_pendingDetailsId = 0;
     m_pendingFormatsId = 0;
     m_pendingVoicesId  = 0;
+    m_voicesLoaded     = false;
     m_languageList->clear();
     m_formatList->clear();
     m_voiceSelector->setVoices({});
@@ -245,7 +248,7 @@ void AudiobookFlowDialog::onDetailsCompleted(quint64 requestId,
 }
 
 void AudiobookFlowDialog::onFormatsCompleted(quint64 requestId,
-                                              QList<BookFormatEntry> formats)
+                                              const QList<BookFormatEntry> &formats)
 {
     if (requestId != m_pendingFormatsId)
         return;
@@ -413,7 +416,9 @@ void AudiobookFlowDialog::populateFormatList()
 
 void AudiobookFlowDialog::populateVoiceList()
 {
-    if (m_worker) {
+    // Voices are global, not per-book — load once per dialog session so
+    // navigating back/forward through step 2 doesn't reset the selection.
+    if (m_worker && !m_voicesLoaded) {
         m_pendingVoicesId = m_requestCounter++;
         emit listVoicesRequested(m_pendingVoicesId);
     }

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -1,0 +1,407 @@
+#include "audiobook_flow_dialog.h"
+#include "voice_upload_dialog.h"
+#include "../widgets/step_indicator_widget.h"
+#include "../widgets/voice_selector_widget.h"
+#include "../widgets/mini_audio_player_widget.h"
+#include "../services/library_service.h"
+#include "../query_worker.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QPushButton>
+#include <QProgressBar>
+#include <QStackedWidget>
+#include <QMessageBox>
+#include <QDesktopServices>
+#include <QUrl>
+#include <QDir>
+#include <QDebug>
+
+namespace bookhub::gui {
+
+AudiobookFlowDialog::AudiobookFlowDialog(LibraryService *libraryService,
+                                         QueryWorker    *worker,
+                                         QWidget        *parent)
+    : QDialog(parent)
+    , m_libraryService(libraryService)
+    , m_worker(worker)
+{
+    setWindowTitle("Convert to Audiobook");
+    setModal(true);
+    setMinimumWidth(560);
+    setMinimumHeight(480);
+
+    m_detailsService = new BookDetailsService(this);
+    connect(m_detailsService, &BookDetailsService::detailsCompleted,
+            this, &AudiobookFlowDialog::onDetailsCompleted);
+    connect(m_detailsService, &BookDetailsService::formatsCompleted,
+            this, &AudiobookFlowDialog::onFormatsCompleted);
+
+    buildUi();
+}
+
+void AudiobookFlowDialog::buildUi()
+{
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+
+    // Title
+    m_titleLabel = new QLabel(this);
+    m_titleLabel->setStyleSheet("font-weight: bold; font-size: 14px;");
+    mainLayout->addWidget(m_titleLabel);
+
+    // Step indicator
+    m_stepIndicator = new StepIndicatorWidget(5, this);
+    m_stepIndicator->setStepLabels({"Lang", "Format", "Voice", "Preview", "Generate"});
+    mainLayout->addWidget(m_stepIndicator);
+
+    // Steps container
+    m_stepsContainer = new QStackedWidget(this);
+    mainLayout->addWidget(m_stepsContainer);
+
+    // Step 1: Language selection
+    QWidget *langStep = new QWidget(this);
+    QVBoxLayout *langLayout = new QVBoxLayout(langStep);
+    m_languageList = new QListWidget(this);
+    m_languageList->setSelectionMode(QAbstractItemView::SingleSelection);
+    connect(m_languageList, &QListWidget::itemSelectionChanged,
+            this, &AudiobookFlowDialog::onLanguageSelectionChanged);
+    langLayout->addWidget(m_languageList);
+    m_stepsContainer->addWidget(langStep);
+
+    // Step 2: Format selection
+    QWidget *formatStep = new QWidget(this);
+    QVBoxLayout *formatLayout = new QVBoxLayout(formatStep);
+    m_formatList = new QListWidget(this);
+    m_formatList->setSelectionMode(QAbstractItemView::SingleSelection);
+    connect(m_formatList, &QListWidget::itemSelectionChanged,
+            this, &AudiobookFlowDialog::onFormatSelectionChanged);
+    formatLayout->addWidget(m_formatList);
+    m_stepsContainer->addWidget(formatStep);
+
+    // Step 3: Voice selection
+    m_voiceSelector = new VoiceSelectorWidget(this);
+    connect(m_voiceSelector, QOverload<int, const QString &>::of(&VoiceSelectorWidget::voiceSelected),
+            this, &AudiobookFlowDialog::onVoiceSelectionChanged);
+    connect(m_voiceSelector, QOverload<int, const QString &>::of(&VoiceSelectorWidget::voicePreviewRequested),
+            this, &AudiobookFlowDialog::onPreviewRequested);
+    connect(m_voiceSelector, &VoiceSelectorWidget::uploadNewVoiceRequested,
+            this, &AudiobookFlowDialog::onVoiceUploadRequested);
+    m_stepsContainer->addWidget(m_voiceSelector);
+
+    // Step 4: Preview
+    QWidget *previewStep = new QWidget(this);
+    QVBoxLayout *previewLayout = new QVBoxLayout(previewStep);
+    QLabel *previewLabel = new QLabel("Listening to: <voice name>", this);
+    previewLayout->addWidget(previewLabel);
+    m_previewText = new QLabel(this);
+    m_previewText->setWordWrap(true);
+    m_previewText->setMaximumHeight(80);
+    previewLayout->addWidget(m_previewText);
+    m_previewPlayer = new MiniAudioPlayerWidget(this);
+    connect(m_previewPlayer, &MiniAudioPlayerWidget::playClicked, this, &AudiobookFlowDialog::onPlayPreview);
+    previewLayout->addWidget(m_previewPlayer);
+    previewLayout->addStretch();
+    m_stepsContainer->addWidget(previewStep);
+
+    // Step 5: Generation
+    QWidget *genStep = new QWidget(this);
+    QVBoxLayout *genLayout = new QVBoxLayout(genStep);
+    genLayout->addSpacing(20);
+    m_progressBar = new QProgressBar(this);
+    m_progressBar->setRange(0, 100);
+    m_progressBar->setValue(0);
+    genLayout->addWidget(m_progressBar);
+    m_progressText = new QLabel("Estimated time: ~4 minutes", this);
+    m_progressText->setAlignment(Qt::AlignCenter);
+    genLayout->addWidget(m_progressText);
+    genLayout->addSpacing(20);
+    m_resultLabel = new QLabel(this);
+    m_resultLabel->setAlignment(Qt::AlignCenter);
+    genLayout->addWidget(m_resultLabel);
+    genLayout->addStretch();
+    m_stepsContainer->addWidget(genStep);
+
+    // Progress container (shown during generation)
+    m_progressContainer = new QWidget(this);
+    QVBoxLayout *progressLayout = new QVBoxLayout(m_progressContainer);
+    progressLayout->addStretch();
+    progressLayout->addWidget(m_progressBar);
+    progressLayout->addWidget(m_progressText);
+    progressLayout->addWidget(m_resultLabel);
+    progressLayout->addStretch();
+    m_progressContainer->hide();
+
+    // Navigation buttons
+    QHBoxLayout *navLayout = new QHBoxLayout();
+    m_backBtn = new QPushButton("← Back", this);
+    m_backBtn->setMaximumWidth(100);
+    connect(m_backBtn, &QPushButton::clicked, this, &AudiobookFlowDialog::onBackClicked);
+    navLayout->addWidget(m_backBtn);
+    navLayout->addStretch();
+
+    m_nextBtn = new QPushButton("Next →", this);
+    m_nextBtn->setMaximumWidth(100);
+    connect(m_nextBtn, &QPushButton::clicked, this, &AudiobookFlowDialog::onNextOrGenerateClicked);
+    navLayout->addWidget(m_nextBtn);
+    mainLayout->addLayout(navLayout);
+
+    setLayout(mainLayout);
+}
+
+void AudiobookFlowDialog::startForBook(const QString &bookId)
+{
+    m_bookId = bookId;
+    resetState();
+    m_pendingDetailsId = m_detailsService->requestBookDetails(bookId);
+}
+
+void AudiobookFlowDialog::resetState()
+{
+    m_currentStep = 0;
+    m_selectedLanguage.clear();
+    m_selectedFormat.clear();
+    m_selectedVoiceId = -1;
+    m_selectedVoiceName.clear();
+    m_languageList->clear();
+    m_formatList->clear();
+    m_voiceSelector->setVoices({});
+    updateStepUi();
+}
+
+void AudiobookFlowDialog::onDetailsCompleted(quint64 requestId,
+                                              const BookDetails &details)
+{
+    if (requestId != m_pendingDetailsId)
+        return;
+
+    m_bookTitle = details.title;
+    m_editions = details.editions;
+    m_libraryItemId = details.libraryItemId;
+    m_titleLabel->setText(QString("Convert to Audiobook — %1").arg(m_bookTitle));
+
+    m_hasLanguageStep = m_editions.size() > 1;
+    populateLanguageList();
+
+    if (!m_hasLanguageStep && !m_editions.isEmpty()) {
+        m_selectedLanguage = m_editions.first().language;
+        m_pendingFormatsId = m_detailsService->requestFormatsForEdition(m_editions.first().editionId);
+    }
+}
+
+void AudiobookFlowDialog::onFormatsCompleted(quint64 requestId,
+                                              QList<BookFormatEntry> formats)
+{
+    if (requestId != m_pendingFormatsId)
+        return;
+
+    m_formats = formats;
+    populateFormatList();
+}
+
+void AudiobookFlowDialog::onLanguageSelectionChanged()
+{
+    QListWidgetItem *item = m_languageList->currentItem();
+    if (!item)
+        return;
+
+    m_selectedLanguage = item->text();
+    // Find the edition ID for the selected language
+    for (const auto &edition : m_editions) {
+        if (edition.language == m_selectedLanguage) {
+            m_pendingFormatsId = m_detailsService->requestFormatsForEdition(edition.editionId);
+            break;
+        }
+    }
+}
+
+void AudiobookFlowDialog::onFormatSelectionChanged()
+{
+    QListWidgetItem *item = m_formatList->currentItem();
+    if (!item)
+        return;
+
+    m_selectedFormat = item->text();
+}
+
+void AudiobookFlowDialog::onVoiceSelectionChanged(int voiceId, const QString &voiceName)
+{
+    m_selectedVoiceId = voiceId;
+    m_selectedVoiceName = voiceName;
+}
+
+void AudiobookFlowDialog::onPreviewRequested(int voiceId, const QString &voiceName)
+{
+    // MVP: placeholder for voice preview generation
+    // In Phase 3+, generate preview audio via TTS service
+    qDebug() << "Preview requested for voice:" << voiceName;
+}
+
+void AudiobookFlowDialog::onVoiceUploadRequested()
+{
+    m_uploadDialog = new VoiceUploadDialog(this);
+    if (m_uploadDialog->exec() == QDialog::Accepted) {
+        QString voiceName = m_uploadDialog->voiceName();
+        // In a real implementation, save voice to DB and refresh voice list
+        qDebug() << "Voice uploaded:" << voiceName;
+    }
+}
+
+void AudiobookFlowDialog::onBackClicked()
+{
+    if (m_currentStep > 0) {
+        m_currentStep--;
+        updateStepUi();
+    }
+}
+
+void AudiobookFlowDialog::onNextOrGenerateClicked()
+{
+    if (m_currentStep < 4) {
+        m_currentStep++;
+        updateStepUi();
+    } else {
+        // Generate audiobook
+        if (startGeneration()) {
+            m_progressBar->setValue(0);
+            m_progressText->setText("Generating audiobook...");
+            m_resultLabel->clear();
+            // In Phase 3+, connect to actual TTS service progress
+            onGenerationProgress(100);
+            onGenerationComplete();
+        }
+    }
+}
+
+void AudiobookFlowDialog::onPlayPreview()
+{
+    // MVP: placeholder for preview playback
+    qDebug() << "Playing preview...";
+}
+
+void AudiobookFlowDialog::onGenerationProgress(int percent)
+{
+    m_progressBar->setValue(percent);
+}
+
+void AudiobookFlowDialog::onGenerationComplete()
+{
+    m_resultLabel->setText("✓ Audiobook ready!");
+    m_nextBtn->setText("Close");
+    m_nextBtn->disconnect();
+    connect(m_nextBtn, &QPushButton::clicked, this, &QDialog::accept);
+}
+
+void AudiobookFlowDialog::onOpenFileClicked()
+{
+    // MVP: placeholder for opening generated file
+    QDesktopServices::openUrl(QUrl::fromLocalFile(QDir::homePath()));
+}
+
+void AudiobookFlowDialog::onAddToLibraryClicked()
+{
+    setLibraryStatus("audiobook_ready");
+    accept();
+}
+
+void AudiobookFlowDialog::populateLanguageList()
+{
+    m_languageList->clear();
+    for (const auto &edition : m_editions) {
+        QListWidgetItem *item = new QListWidgetItem(edition.language);
+        m_languageList->addItem(item);
+    }
+    if (!m_editions.isEmpty()) {
+        m_languageList->setCurrentRow(0);
+    }
+}
+
+void AudiobookFlowDialog::populateFormatList()
+{
+    m_formatList->clear();
+    for (const auto &format : m_formats) {
+        QString label = format.formatType;
+        if (format.formatType == "epub") {
+            label += " (recommended)";
+        }
+        QListWidgetItem *item = new QListWidgetItem(label);
+        m_formatList->addItem(item);
+    }
+    if (!m_formats.isEmpty()) {
+        m_formatList->setCurrentRow(0);
+        if (m_formats.first().formatType == "epub") {
+            m_selectedFormat = "epub";
+        } else {
+            m_selectedFormat = m_formats.first().formatType;
+        }
+    }
+}
+
+void AudiobookFlowDialog::populateVoiceList()
+{
+    // Load voices from database
+    QList<VoiceEntry> voices;
+    voices.append({1, "Classic Storyteller", true});
+    voices.append({2, "Warm Listener", true});
+    voices.append({3, "Crisp Narrator", true});
+    // In Phase 3+, also load custom voices from DB
+    m_voiceSelector->setVoices(voices);
+}
+
+void AudiobookFlowDialog::updateStepUi()
+{
+    m_stepIndicator->setCurrentStep(m_currentStep);
+    m_stepsContainer->setCurrentIndex(m_currentStep);
+
+    // Update button labels
+    m_backBtn->setVisible(m_currentStep > 0);
+    if (m_currentStep == 4) {
+        m_nextBtn->setText("✓ Confirm & Generate");
+    } else {
+        m_nextBtn->setText("Next →");
+    }
+
+    // Populate step-specific data
+    if (m_currentStep == 0 && m_hasLanguageStep) {
+        populateLanguageList();
+    } else if (m_currentStep == 1) {
+        populateFormatList();
+    } else if (m_currentStep == 2) {
+        populateVoiceList();
+    }
+}
+
+bool AudiobookFlowDialog::startGeneration()
+{
+    if (m_selectedLanguage.isEmpty() || m_selectedFormat.isEmpty() || m_selectedVoiceId < 0) {
+        showErrorState("Please select language, format, and voice.");
+        return false;
+    }
+    // MVP: placeholder for actual generation
+    return true;
+}
+
+void AudiobookFlowDialog::setLibraryStatus(const QString &status)
+{
+    if (m_libraryItemId > 0 && m_libraryService) {
+        // In Phase 3+, call LibraryService to update status in DB
+        qDebug() << "Setting library status to:" << status;
+    }
+}
+
+BookSourceEntry AudiobookFlowDialog::selectedSource() const
+{
+    // MVP: return first available source
+    if (!m_formats.isEmpty() && !m_formats.first().sources.isEmpty()) {
+        return m_formats.first().sources.first();
+    }
+    return BookSourceEntry{};
+}
+
+void AudiobookFlowDialog::showErrorState(const QString &message)
+{
+    QMessageBox::warning(this, "Error", message);
+}
+
+} // namespace bookhub::gui

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -139,7 +139,7 @@ void AudiobookFlowDialog::buildUi()
     m_resultLabel = new QLabel(this);
     m_resultLabel->setAlignment(Qt::AlignCenter);
     genLayout->addWidget(m_resultLabel);
-    // Cancel button — visible during generation, hidden once complete (Phase 3)
+    // TODO: Phase 3 — show during async TTS generation; connect to TTSService::cancel().
     m_cancelGenBtn = new QPushButton("Cancel", this);
     m_cancelGenBtn->hide();
     genLayout->addWidget(m_cancelGenBtn, 0, Qt::AlignHCenter);
@@ -368,6 +368,9 @@ void AudiobookFlowDialog::onOpenFileClicked()
 
 void AudiobookFlowDialog::onAddToLibraryClicked()
 {
+    // TODO: Phase 3 — wait for audiobookConversionCompleted signal before
+    // closing so a failed DB write surfaces an error rather than silently
+    // dropping the status update.
     markAudiobookReady();
     accept();
 }

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -30,6 +30,8 @@ AudiobookFlowDialog::AudiobookFlowDialog(LibraryService *libraryService,
     setMinimumHeight(480);
 
     m_detailsService = new BookDetailsService(this);
+    if (m_worker)
+        m_detailsService->connectToWorker(m_worker);
     connect(m_detailsService, &BookDetailsService::detailsCompleted,
             this, &AudiobookFlowDialog::onDetailsCompleted);
     connect(m_detailsService, &BookDetailsService::formatsCompleted,
@@ -177,7 +179,10 @@ void AudiobookFlowDialog::startForBook(const QString &bookId)
 {
     m_bookId = bookId;
     resetState();
-    m_pendingDetailsId = m_detailsService->requestBookDetails(bookId);
+    // Capture the id before emit so a same-thread (synchronous) reply from the
+    // worker still matches m_pendingDetailsId in the completion slot.
+    m_pendingDetailsId = m_detailsService->peekNextId();
+    m_detailsService->requestBookDetails(bookId);
 }
 
 void AudiobookFlowDialog::resetState()
@@ -226,7 +231,8 @@ void AudiobookFlowDialog::onDetailsCompleted(quint64 requestId,
 
     if (!m_hasLanguageStep && !m_editions.isEmpty()) {
         m_selectedLanguage = m_editions.first().language;
-        m_pendingFormatsId = m_detailsService->requestFormatsForEdition(m_editions.first().editionId);
+        m_pendingFormatsId = m_detailsService->peekNextId();
+        m_detailsService->requestFormatsForEdition(m_editions.first().editionId);
         // Skip the pointless single-language step and open directly on format selection.
         m_currentStep = 1;
         updateStepUi();
@@ -252,10 +258,12 @@ void AudiobookFlowDialog::onLanguageSelectionChanged()
     m_selectedLanguage = item->text();
     for (const auto &edition : m_editions) {
         if (edition.language == m_selectedLanguage) {
-            m_pendingFormatsId = m_detailsService->requestFormatsForEdition(edition.editionId);
+            m_pendingFormatsId = m_detailsService->peekNextId();
+            m_detailsService->requestFormatsForEdition(edition.editionId);
             break;
         }
     }
+    updateNextButtonEnabled();
 }
 
 void AudiobookFlowDialog::onFormatSelectionChanged()
@@ -265,6 +273,7 @@ void AudiobookFlowDialog::onFormatSelectionChanged()
         return;
 
     m_selectedFormat = item->text().split(" (")[0]; // strip "(recommended)" suffix
+    updateNextButtonEnabled();
 }
 
 void AudiobookFlowDialog::onVoiceSelectionChanged(int voiceId, const QString &voiceName)
@@ -275,6 +284,7 @@ void AudiobookFlowDialog::onVoiceSelectionChanged(int voiceId, const QString &vo
     m_previewVoiceLabel->setText(voiceId >= 0
         ? QString("Listening to: %1").arg(voiceName)
         : QStringLiteral("Listening to: —"));
+    updateNextButtonEnabled();
 }
 
 void AudiobookFlowDialog::onVoiceUploadRequested()
@@ -332,7 +342,13 @@ void AudiobookFlowDialog::onGenerationComplete()
     m_progressText->hide();
     m_cancelGenBtn->hide();
     m_openFileBtn->show();   // Phase 3: open generated audio file
-    m_addToLibBtn->show();   // Phase 3: explicit user action to mark ready
+    // Add-to-library only writes a row that already exists; if the book is not
+    // in the library, the SQL UPDATE silently affects 0 rows. Hide the button
+    // in that case so the click cannot misleadingly succeed.
+    if (m_libraryItemId > 0)
+        m_addToLibBtn->show();
+    else
+        m_addToLibBtn->hide();
     m_nextBtn->setText("Close");
     disconnect(m_nextBtn, &QPushButton::clicked,
                this, &AudiobookFlowDialog::onNextOrGenerateClicked);
@@ -409,6 +425,23 @@ void AudiobookFlowDialog::updateStepUi()
         populateFormatList();
     else if (m_currentStep == 2)
         populateVoiceList();
+
+    updateNextButtonEnabled();
+}
+
+void AudiobookFlowDialog::updateNextButtonEnabled()
+{
+    // Each step gates Next on its own selection so the user cannot reach the
+    // generate step with empty fields. Steps 3 (preview) and 4 (generate) need
+    // no extra input — Next is always enabled there.
+    bool enabled = true;
+    switch (m_currentStep) {
+        case 0: enabled = !m_selectedLanguage.isEmpty(); break;
+        case 1: enabled = !m_selectedFormat.isEmpty();   break;
+        case 2: enabled = m_selectedVoiceId >= 0;        break;
+        default: enabled = true;                         break;
+    }
+    m_nextBtn->setEnabled(enabled);
 }
 
 bool AudiobookFlowDialog::startGeneration()

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -167,8 +167,6 @@ void AudiobookFlowDialog::buildUi()
 
     m_nextBtn = new QPushButton("Next →", this);
     m_nextBtn->setMaximumWidth(100);
-    connect(m_nextBtn, &QPushButton::clicked,
-            this, &AudiobookFlowDialog::onNextOrGenerateClicked);
     navLayout->addWidget(m_nextBtn);
     mainLayout->addLayout(navLayout);
 
@@ -192,6 +190,23 @@ void AudiobookFlowDialog::resetState()
     m_languageList->clear();
     m_formatList->clear();
     m_voiceSelector->setVoices({});
+
+    // Restore Next button to navigation mode. onGenerationComplete() rewires it
+    // to QDialog::accept; without this reset, reopening the dialog for a second
+    // book leaves every "Next" click accepting the dialog immediately.
+    disconnect(m_nextBtn, &QPushButton::clicked, nullptr, nullptr);
+    connect(m_nextBtn, &QPushButton::clicked,
+            this, &AudiobookFlowDialog::onNextOrGenerateClicked);
+
+    // Reset generation step widgets to their initial state
+    m_progressBar->setValue(0);
+    m_progressText->setText("Estimated time: ~4 minutes");
+    m_progressText->show();
+    m_resultLabel->clear();
+    m_cancelGenBtn->hide();
+    m_openFileBtn->hide();
+    m_addToLibBtn->hide();
+
     updateStepUi();
 }
 
@@ -404,8 +419,10 @@ void AudiobookFlowDialog::markAudiobookReady()
 
 BookSourceEntry AudiobookFlowDialog::selectedSource() const
 {
-    if (!m_formats.isEmpty() && !m_formats.first().sources.isEmpty())
-        return m_formats.first().sources.first();
+    for (const auto &fmt : m_formats) {
+        if (fmt.formatType == m_selectedFormat && !fmt.sources.isEmpty())
+            return fmt.sources.first();
+    }
     return BookSourceEntry{};
 }
 

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -14,11 +14,6 @@
 #include <QProgressBar>
 #include <QStackedWidget>
 #include <QMessageBox>
-#include <QDesktopServices>
-#include <QUrl>
-#include <QDir>
-#include <QDebug>
-#include <QDateTime>
 
 namespace bookhub::gui {
 
@@ -40,24 +35,37 @@ AudiobookFlowDialog::AudiobookFlowDialog(LibraryService *libraryService,
     connect(m_detailsService, &BookDetailsService::formatsCompleted,
             this, &AudiobookFlowDialog::onFormatsCompleted);
 
+    if (m_worker) {
+        // Route listVoicesRequested through Qt's connection mechanism so the
+        // call is queued when m_worker lives on the query thread.
+        connect(this, &AudiobookFlowDialog::listVoicesRequested,
+                m_worker, &QueryWorker::handleListVoicesRequest);
+
+        connect(m_worker,
+                QOverload<quint64, QList<VoiceEntry>>::of(&QueryWorker::listVoicesCompleted),
+                this,
+                [this](quint64 requestId, const QList<VoiceEntry> &voices) {
+                    if (requestId == m_pendingVoicesId && m_voiceSelector)
+                        m_voiceSelector->setVoices(voices);
+                });
+    }
+
     buildUi();
+    resetState();
 }
 
 void AudiobookFlowDialog::buildUi()
 {
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
-    // Title
     m_titleLabel = new QLabel(this);
     m_titleLabel->setStyleSheet("font-weight: bold; font-size: 14px;");
     mainLayout->addWidget(m_titleLabel);
 
-    // Step indicator
     m_stepIndicator = new StepIndicatorWidget(5, this);
     m_stepIndicator->setStepLabels({"Lang", "Format", "Voice", "Preview", "Generate"});
     mainLayout->addWidget(m_stepIndicator);
 
-    // Steps container
     m_stepsContainer = new QStackedWidget(this);
     mainLayout->addWidget(m_stepsContainer);
 
@@ -83,10 +91,8 @@ void AudiobookFlowDialog::buildUi()
 
     // Step 3: Voice selection
     m_voiceSelector = new VoiceSelectorWidget(this);
-    connect(m_voiceSelector, QOverload<int, const QString &>::of(&VoiceSelectorWidget::voiceSelected),
+    connect(m_voiceSelector, &VoiceSelectorWidget::voiceSelected,
             this, &AudiobookFlowDialog::onVoiceSelectionChanged);
-    connect(m_voiceSelector, QOverload<int, const QString &>::of(&VoiceSelectorWidget::voicePreviewRequested),
-            this, &AudiobookFlowDialog::onPreviewRequested);
     connect(m_voiceSelector, &VoiceSelectorWidget::uploadNewVoiceRequested,
             this, &AudiobookFlowDialog::onVoiceUploadRequested);
     m_stepsContainer->addWidget(m_voiceSelector);
@@ -101,12 +107,13 @@ void AudiobookFlowDialog::buildUi()
     m_previewText->setMaximumHeight(80);
     previewLayout->addWidget(m_previewText);
     m_previewPlayer = new MiniAudioPlayerWidget(this);
-    connect(m_previewPlayer, &MiniAudioPlayerWidget::playClicked, this, &AudiobookFlowDialog::onPlayPreview);
+    connect(m_previewPlayer, &MiniAudioPlayerWidget::playClicked,
+            this, &AudiobookFlowDialog::onPlayPreview);
     previewLayout->addWidget(m_previewPlayer);
     previewLayout->addStretch();
     m_stepsContainer->addWidget(previewStep);
 
-    // Step 5: Generation
+    // Step 5: Generation — all progress widgets live here, no double-parenting
     QWidget *genStep = new QWidget(this);
     QVBoxLayout *genLayout = new QVBoxLayout(genStep);
     genLayout->addSpacing(20);
@@ -124,17 +131,7 @@ void AudiobookFlowDialog::buildUi()
     genLayout->addStretch();
     m_stepsContainer->addWidget(genStep);
 
-    // Progress container (shown during generation)
-    m_progressContainer = new QWidget(this);
-    QVBoxLayout *progressLayout = new QVBoxLayout(m_progressContainer);
-    progressLayout->addStretch();
-    progressLayout->addWidget(m_progressBar);
-    progressLayout->addWidget(m_progressText);
-    progressLayout->addWidget(m_resultLabel);
-    progressLayout->addStretch();
-    m_progressContainer->hide();
-
-    // Navigation buttons
+    // Navigation
     QHBoxLayout *navLayout = new QHBoxLayout();
     m_backBtn = new QPushButton("← Back", this);
     m_backBtn->setMaximumWidth(100);
@@ -144,7 +141,8 @@ void AudiobookFlowDialog::buildUi()
 
     m_nextBtn = new QPushButton("Next →", this);
     m_nextBtn->setMaximumWidth(100);
-    connect(m_nextBtn, &QPushButton::clicked, this, &AudiobookFlowDialog::onNextOrGenerateClicked);
+    connect(m_nextBtn, &QPushButton::clicked,
+            this, &AudiobookFlowDialog::onNextOrGenerateClicked);
     navLayout->addWidget(m_nextBtn);
     mainLayout->addLayout(navLayout);
 
@@ -208,7 +206,6 @@ void AudiobookFlowDialog::onLanguageSelectionChanged()
         return;
 
     m_selectedLanguage = item->text();
-    // Find the edition ID for the selected language
     for (const auto &edition : m_editions) {
         if (edition.language == m_selectedLanguage) {
             m_pendingFormatsId = m_detailsService->requestFormatsForEdition(edition.editionId);
@@ -223,7 +220,7 @@ void AudiobookFlowDialog::onFormatSelectionChanged()
     if (!item)
         return;
 
-    m_selectedFormat = item->text();
+    m_selectedFormat = item->text().split(" (")[0]; // strip "(recommended)" suffix
 }
 
 void AudiobookFlowDialog::onVoiceSelectionChanged(int voiceId, const QString &voiceName)
@@ -232,21 +229,11 @@ void AudiobookFlowDialog::onVoiceSelectionChanged(int voiceId, const QString &vo
     m_selectedVoiceName = voiceName;
 }
 
-void AudiobookFlowDialog::onPreviewRequested([[maybe_unused]] int voiceId, const QString &voiceName)
-{
-    // MVP: placeholder for voice preview generation
-    // In Phase 3+, generate preview audio via TTS service
-    qDebug() << "Preview requested for voice:" << voiceName;
-}
-
 void AudiobookFlowDialog::onVoiceUploadRequested()
 {
     m_uploadDialog = new VoiceUploadDialog(this);
-    if (m_uploadDialog->exec() == QDialog::Accepted) {
-        QString voiceName = m_uploadDialog->voiceName();
-        // In a real implementation, save voice to DB and refresh voice list
-        qDebug() << "Voice uploaded:" << voiceName;
-    }
+    if (m_uploadDialog->exec() == QDialog::Accepted)
+        populateVoiceList(); // refresh list after upload (DB insertion deferred to Phase 3)
 }
 
 void AudiobookFlowDialog::onBackClicked()
@@ -263,12 +250,11 @@ void AudiobookFlowDialog::onNextOrGenerateClicked()
         m_currentStep++;
         updateStepUi();
     } else {
-        // Generate audiobook
         if (startGeneration()) {
             m_progressBar->setValue(0);
             m_progressText->setText("Generating audiobook...");
             m_resultLabel->clear();
-            // In Phase 3+, connect to actual TTS service progress
+            // Phase 3+: connect to actual TTS service progress
             onGenerationProgress(100);
             onGenerationComplete();
         }
@@ -277,8 +263,7 @@ void AudiobookFlowDialog::onNextOrGenerateClicked()
 
 void AudiobookFlowDialog::onPlayPreview()
 {
-    // MVP: placeholder for preview playback
-    qDebug() << "Playing preview...";
+    // Phase 3+: generate and play preview audio via TTSService
 }
 
 void AudiobookFlowDialog::onGenerationProgress(int percent)
@@ -290,20 +275,10 @@ void AudiobookFlowDialog::onGenerationComplete()
 {
     m_resultLabel->setText("✓ Audiobook ready!");
     m_nextBtn->setText("Close");
-    m_nextBtn->disconnect();
+    disconnect(m_nextBtn, &QPushButton::clicked,
+               this, &AudiobookFlowDialog::onNextOrGenerateClicked);
     connect(m_nextBtn, &QPushButton::clicked, this, &QDialog::accept);
-}
-
-void AudiobookFlowDialog::onOpenFileClicked()
-{
-    // MVP: placeholder for opening generated file
-    QDesktopServices::openUrl(QUrl::fromLocalFile(QDir::homePath()));
-}
-
-void AudiobookFlowDialog::onAddToLibraryClicked()
-{
-    setLibraryStatus("audiobook_ready");
-    accept();
+    setLibraryStatus(QStringLiteral("audiobook_ready"));
 }
 
 void AudiobookFlowDialog::populateLanguageList()
@@ -313,9 +288,8 @@ void AudiobookFlowDialog::populateLanguageList()
         QListWidgetItem *item = new QListWidgetItem(edition.language);
         m_languageList->addItem(item);
     }
-    if (!m_editions.isEmpty()) {
+    if (!m_editions.isEmpty())
         m_languageList->setCurrentRow(0);
-    }
 }
 
 void AudiobookFlowDialog::populateFormatList()
@@ -323,38 +297,21 @@ void AudiobookFlowDialog::populateFormatList()
     m_formatList->clear();
     for (const auto &format : m_formats) {
         QString label = format.formatType;
-        if (format.formatType == "epub") {
+        if (format.formatType == QLatin1String("epub"))
             label += " (recommended)";
-        }
-        QListWidgetItem *item = new QListWidgetItem(label);
-        m_formatList->addItem(item);
+        m_formatList->addItem(new QListWidgetItem(label));
     }
     if (!m_formats.isEmpty()) {
         m_formatList->setCurrentRow(0);
-        if (m_formats.first().formatType == "epub") {
-            m_selectedFormat = "epub";
-        } else {
-            m_selectedFormat = m_formats.first().formatType;
-        }
+        m_selectedFormat = m_formats.first().formatType;
     }
 }
 
 void AudiobookFlowDialog::populateVoiceList()
 {
-    // Request voices from database via query worker
     if (m_worker) {
-        m_pendingVoicesId = reinterpret_cast<quint64>(this) ^ QDateTime::currentMSecsSinceEpoch();
-        // Use lambda to handle result without adding slot to Q_OBJECT
-        connect(m_worker,
-                QOverload<quint64, QList<VoiceEntry>>::of(&QueryWorker::listVoicesCompleted),
-                this,
-                [this](quint64 requestId, QList<VoiceEntry> voices) {
-                    if (requestId == m_pendingVoicesId && m_voiceSelector) {
-                        m_voiceSelector->setVoices(voices);
-                    }
-                },
-                Qt::UniqueConnection);
-        m_worker->handleListVoicesRequest(m_pendingVoicesId);
+        m_pendingVoicesId = m_requestCounter.fetch_add(1);
+        emit listVoicesRequested(m_pendingVoicesId);
     }
 }
 
@@ -363,22 +320,17 @@ void AudiobookFlowDialog::updateStepUi()
     m_stepIndicator->setCurrentStep(m_currentStep);
     m_stepsContainer->setCurrentIndex(m_currentStep);
 
-    // Update button labels
     m_backBtn->setVisible(m_currentStep > 0);
-    if (m_currentStep == 4) {
-        m_nextBtn->setText("✓ Confirm & Generate");
-    } else {
-        m_nextBtn->setText("Next →");
-    }
+    m_nextBtn->setText(m_currentStep == 4
+        ? QStringLiteral("✓ Confirm & Generate")
+        : QStringLiteral("Next →"));
 
-    // Populate step-specific data
-    if (m_currentStep == 0 && m_hasLanguageStep) {
+    if (m_currentStep == 0 && m_hasLanguageStep)
         populateLanguageList();
-    } else if (m_currentStep == 1) {
+    else if (m_currentStep == 1)
         populateFormatList();
-    } else if (m_currentStep == 2) {
+    else if (m_currentStep == 2)
         populateVoiceList();
-    }
 }
 
 bool AudiobookFlowDialog::startGeneration()
@@ -387,24 +339,19 @@ bool AudiobookFlowDialog::startGeneration()
         showErrorState("Please select language, format, and voice.");
         return false;
     }
-    // MVP: placeholder for actual generation
     return true;
 }
 
-void AudiobookFlowDialog::setLibraryStatus(const QString &status)
+void AudiobookFlowDialog::setLibraryStatus(const QString &)
 {
-    if (m_libraryItemId > 0 && m_libraryService) {
-        // In Phase 3+, call LibraryService to update status in DB
-        qDebug() << "Setting library status to:" << status;
-    }
+    if (m_libraryItemId > 0 && m_libraryService)
+        m_libraryService->requestSetAudiobookReady(m_bookId);
 }
 
 BookSourceEntry AudiobookFlowDialog::selectedSource() const
 {
-    // MVP: return first available source
-    if (!m_formats.isEmpty() && !m_formats.first().sources.isEmpty()) {
+    if (!m_formats.isEmpty() && !m_formats.first().sources.isEmpty())
         return m_formats.first().sources.first();
-    }
     return BookSourceEntry{};
 }
 

--- a/src/gui/dialogs/audiobook_flow_dialog.cpp
+++ b/src/gui/dialogs/audiobook_flow_dialog.cpp
@@ -90,12 +90,21 @@ void AudiobookFlowDialog::buildUi()
     m_stepsContainer->addWidget(formatStep);
 
     // Step 3: Voice selection
+    QWidget *voiceStep = new QWidget(this);
+    QVBoxLayout *voiceLayout = new QVBoxLayout(voiceStep);
     m_voiceSelector = new VoiceSelectorWidget(this);
     connect(m_voiceSelector, &VoiceSelectorWidget::voiceSelected,
             this, &AudiobookFlowDialog::onVoiceSelectionChanged);
     connect(m_voiceSelector, &VoiceSelectorWidget::uploadNewVoiceRequested,
             this, &AudiobookFlowDialog::onVoiceUploadRequested);
-    m_stepsContainer->addWidget(m_voiceSelector);
+    voiceLayout->addWidget(m_voiceSelector);
+    // Phase 3: connect to TTSService to generate a 10-second preview clip
+    m_previewVoiceBtn = new QPushButton("▶ Preview selected voice", this);
+    m_previewVoiceBtn->setEnabled(false); // enabled once a voice is selected
+    connect(m_previewVoiceBtn, &QPushButton::clicked,
+            this, &AudiobookFlowDialog::onPreviewVoiceClicked);
+    voiceLayout->addWidget(m_previewVoiceBtn);
+    m_stepsContainer->addWidget(voiceStep);
 
     // Step 4: Preview
     QWidget *previewStep = new QWidget(this);
@@ -128,6 +137,23 @@ void AudiobookFlowDialog::buildUi()
     m_resultLabel = new QLabel(this);
     m_resultLabel->setAlignment(Qt::AlignCenter);
     genLayout->addWidget(m_resultLabel);
+    // Cancel button — visible during generation, hidden once complete (Phase 3)
+    m_cancelGenBtn = new QPushButton("Cancel", this);
+    m_cancelGenBtn->hide();
+    genLayout->addWidget(m_cancelGenBtn, 0, Qt::AlignHCenter);
+    // Post-generation action buttons — hidden until generation completes (Phase 3)
+    QHBoxLayout *postGenLayout = new QHBoxLayout();
+    m_openFileBtn = new QPushButton("Open file", this);
+    m_openFileBtn->hide();
+    connect(m_openFileBtn, &QPushButton::clicked,
+            this, &AudiobookFlowDialog::onOpenFileClicked);
+    m_addToLibBtn = new QPushButton("Add to library", this);
+    m_addToLibBtn->hide();
+    connect(m_addToLibBtn, &QPushButton::clicked,
+            this, &AudiobookFlowDialog::onAddToLibraryClicked);
+    postGenLayout->addWidget(m_openFileBtn);
+    postGenLayout->addWidget(m_addToLibBtn);
+    genLayout->addLayout(postGenLayout);
     genLayout->addStretch();
     m_stepsContainer->addWidget(genStep);
 
@@ -227,6 +253,7 @@ void AudiobookFlowDialog::onVoiceSelectionChanged(int voiceId, const QString &vo
 {
     m_selectedVoiceId = voiceId;
     m_selectedVoiceName = voiceName;
+    m_previewVoiceBtn->setEnabled(voiceId >= 0);
 }
 
 void AudiobookFlowDialog::onVoiceUploadRequested()
@@ -274,11 +301,31 @@ void AudiobookFlowDialog::onGenerationProgress(int percent)
 void AudiobookFlowDialog::onGenerationComplete()
 {
     m_resultLabel->setText("✓ Audiobook ready!");
+    m_progressText->hide();
+    m_cancelGenBtn->hide();
+    m_openFileBtn->show();   // Phase 3: open generated audio file
+    m_addToLibBtn->show();   // Phase 3: explicit user action to mark ready
     m_nextBtn->setText("Close");
     disconnect(m_nextBtn, &QPushButton::clicked,
                this, &AudiobookFlowDialog::onNextOrGenerateClicked);
     connect(m_nextBtn, &QPushButton::clicked, this, &QDialog::accept);
     setLibraryStatus(QStringLiteral("audiobook_ready"));
+}
+
+void AudiobookFlowDialog::onPreviewVoiceClicked()
+{
+    // Phase 3: request a 10-second preview clip from TTSService for m_selectedVoiceName
+}
+
+void AudiobookFlowDialog::onOpenFileClicked()
+{
+    // Phase 3: open generated audio file via QDesktopServices::openUrl()
+}
+
+void AudiobookFlowDialog::onAddToLibraryClicked()
+{
+    setLibraryStatus(QStringLiteral("audiobook_ready"));
+    accept();
 }
 
 void AudiobookFlowDialog::populateLanguageList()

--- a/src/gui/dialogs/audiobook_flow_dialog.h
+++ b/src/gui/dialogs/audiobook_flow_dialog.h
@@ -71,6 +71,7 @@ private:
 
     quint64 m_pendingDetailsId{0};
     quint64 m_pendingFormatsId{0};
+    quint64 m_pendingVoicesId{0};
 
     int     m_currentStep{0}; // 0=language, 1=format, 2=voice, 3=preview, 4=generate
 

--- a/src/gui/dialogs/audiobook_flow_dialog.h
+++ b/src/gui/dialogs/audiobook_flow_dialog.h
@@ -2,7 +2,6 @@
 
 #include "../services/book_details_service.h"
 #include <QDialog>
-#include <atomic>
 
 class QLabel;
 class QListWidget;
@@ -76,7 +75,7 @@ private:
     QList<BookFormatEntry>  m_formats;
     bool    m_hasLanguageStep{false};
 
-    std::atomic<quint64> m_requestCounter{1};
+    quint64 m_requestCounter{1};
 
     quint64 m_pendingDetailsId{0};
     quint64 m_pendingFormatsId{0};

--- a/src/gui/dialogs/audiobook_flow_dialog.h
+++ b/src/gui/dialogs/audiobook_flow_dialog.h
@@ -107,8 +107,6 @@ private:
     QLabel                *m_previewVoiceLabel{}; // shows selected voice name in step 4
     MiniAudioPlayerWidget *m_previewPlayer{};
     QLabel                *m_previewText{};
-
-    VoiceUploadDialog *m_uploadDialog{};
 };
 
 } // namespace bookhub::gui

--- a/src/gui/dialogs/audiobook_flow_dialog.h
+++ b/src/gui/dialogs/audiobook_flow_dialog.h
@@ -58,7 +58,7 @@ private:
     void populateFormatList();
     void populateVoiceList();
     bool startGeneration();
-    void setLibraryStatus(const QString &status);
+    void markAudiobookReady();
     BookSourceEntry selectedSource() const;
     void showErrorState(const QString &message);
 
@@ -104,6 +104,7 @@ private:
     QListWidget *m_formatList{};
     VoiceSelectorWidget   *m_voiceSelector{};
     QPushButton           *m_previewVoiceBtn{};  // preview selected voice (Phase 3)
+    QLabel                *m_previewVoiceLabel{}; // shows selected voice name in step 4
     MiniAudioPlayerWidget *m_previewPlayer{};
     QLabel                *m_previewText{};
 

--- a/src/gui/dialogs/audiobook_flow_dialog.h
+++ b/src/gui/dialogs/audiobook_flow_dialog.h
@@ -35,7 +35,7 @@ signals:
 private slots:
     void onDetailsCompleted(quint64 requestId, const bookhub::gui::BookDetails &details);
     void onFormatsCompleted(quint64 requestId,
-                            QList<bookhub::gui::BookFormatEntry> formats);
+                            const QList<bookhub::gui::BookFormatEntry> &formats);
     void onLanguageSelectionChanged();
     void onFormatSelectionChanged();
     void onVoiceSelectionChanged(int voiceId, const QString &voiceName);
@@ -80,6 +80,9 @@ private:
     quint64 m_pendingDetailsId{0};
     quint64 m_pendingFormatsId{0};
     quint64 m_pendingVoicesId{0};
+    // Set once voices have been loaded so back/forward navigation through
+    // step 2 doesn't re-fire the query and clobber the user's selection.
+    bool    m_voicesLoaded{false};
 
     int     m_currentStep{0}; // 0=language, 1=format, 2=voice, 3=preview, 4=generate
 

--- a/src/gui/dialogs/audiobook_flow_dialog.h
+++ b/src/gui/dialogs/audiobook_flow_dialog.h
@@ -2,6 +2,7 @@
 
 #include "../services/book_details_service.h"
 #include <QDialog>
+#include <atomic>
 
 class QLabel;
 class QListWidget;
@@ -17,6 +18,7 @@ class StepIndicatorWidget;
 class VoiceSelectorWidget;
 class MiniAudioPlayerWidget;
 class VoiceUploadDialog;
+class AudiobookFlowDialogTest;
 
 class AudiobookFlowDialog : public QDialog {
     Q_OBJECT
@@ -28,6 +30,9 @@ public:
 
     void startForBook(const QString &bookId);
 
+signals:
+    void listVoicesRequested(quint64 requestId);
+
 private slots:
     void onDetailsCompleted(quint64 requestId, const bookhub::gui::BookDetails &details);
     void onFormatsCompleted(quint64 requestId,
@@ -35,15 +40,12 @@ private slots:
     void onLanguageSelectionChanged();
     void onFormatSelectionChanged();
     void onVoiceSelectionChanged(int voiceId, const QString &voiceName);
-    void onPreviewRequested(int voiceId, const QString &voiceName);
     void onVoiceUploadRequested();
     void onBackClicked();
     void onNextOrGenerateClicked();
     void onPlayPreview();
     void onGenerationProgress(int percent);
     void onGenerationComplete();
-    void onOpenFileClicked();
-    void onAddToLibraryClicked();
 
 private:
     void buildUi();
@@ -52,11 +54,12 @@ private:
     void populateLanguageList();
     void populateFormatList();
     void populateVoiceList();
-    void requestFormatsForSelectedLanguage();
     bool startGeneration();
     void setLibraryStatus(const QString &status);
     BookSourceEntry selectedSource() const;
     void showErrorState(const QString &message);
+
+    friend class ::bookhub::gui::AudiobookFlowDialogTest;
 
     LibraryService        *m_libraryService{};
     BookDetailsService    *m_detailsService{};
@@ -68,6 +71,8 @@ private:
     QList<BookEditionEntry> m_editions;
     QList<BookFormatEntry>  m_formats;
     bool    m_hasLanguageStep{false};
+
+    std::atomic<quint64> m_requestCounter{1};
 
     quint64 m_pendingDetailsId{0};
     quint64 m_pendingFormatsId{0};
@@ -81,22 +86,19 @@ private:
     QString m_selectedVoiceName;
 
     QLabel               *m_titleLabel{};
-    QLabel               *m_stepLabel{};
     StepIndicatorWidget  *m_stepIndicator{};
     QStackedWidget       *m_stepsContainer{};
-    QWidget              *m_progressContainer{};
     QProgressBar         *m_progressBar{};
     QLabel               *m_progressText{};
     QLabel               *m_resultLabel{};
     QPushButton          *m_backBtn{};
     QPushButton          *m_nextBtn{};
 
-    // Step widgets (will be allocated in buildUi)
     QListWidget *m_languageList{};
     QListWidget *m_formatList{};
-    VoiceSelectorWidget *m_voiceSelector{};
+    VoiceSelectorWidget   *m_voiceSelector{};
     MiniAudioPlayerWidget *m_previewPlayer{};
-    QLabel *m_previewText{};
+    QLabel                *m_previewText{};
 
     VoiceUploadDialog *m_uploadDialog{};
 };

--- a/src/gui/dialogs/audiobook_flow_dialog.h
+++ b/src/gui/dialogs/audiobook_flow_dialog.h
@@ -46,6 +46,9 @@ private slots:
     void onPlayPreview();
     void onGenerationProgress(int percent);
     void onGenerationComplete();
+    void onPreviewVoiceClicked();   // Phase 3: generate 10-second preview via TTSService
+    void onOpenFileClicked();       // Phase 3: open generated file via QDesktopServices
+    void onAddToLibraryClicked();   // Phase 3: update library status to audiobook_ready
 
 private:
     void buildUi();
@@ -91,12 +94,16 @@ private:
     QProgressBar         *m_progressBar{};
     QLabel               *m_progressText{};
     QLabel               *m_resultLabel{};
+    QPushButton          *m_cancelGenBtn{};  // visible during generation
+    QPushButton          *m_openFileBtn{};   // visible after completion
+    QPushButton          *m_addToLibBtn{};   // visible after completion
     QPushButton          *m_backBtn{};
     QPushButton          *m_nextBtn{};
 
     QListWidget *m_languageList{};
     QListWidget *m_formatList{};
     VoiceSelectorWidget   *m_voiceSelector{};
+    QPushButton           *m_previewVoiceBtn{};  // preview selected voice (Phase 3)
     MiniAudioPlayerWidget *m_previewPlayer{};
     QLabel                *m_previewText{};
 

--- a/src/gui/dialogs/audiobook_flow_dialog.h
+++ b/src/gui/dialogs/audiobook_flow_dialog.h
@@ -54,6 +54,7 @@ private:
     void buildUi();
     void resetState();
     void updateStepUi();
+    void updateNextButtonEnabled();
     void populateLanguageList();
     void populateFormatList();
     void populateVoiceList();

--- a/src/gui/dialogs/audiobook_flow_dialog.h
+++ b/src/gui/dialogs/audiobook_flow_dialog.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "../services/book_details_service.h"
+#include <QDialog>
+
+class QLabel;
+class QListWidget;
+class QPushButton;
+class QProgressBar;
+class QStackedWidget;
+
+namespace bookhub::gui {
+
+class LibraryService;
+class QueryWorker;
+class StepIndicatorWidget;
+class VoiceSelectorWidget;
+class MiniAudioPlayerWidget;
+class VoiceUploadDialog;
+
+class AudiobookFlowDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit AudiobookFlowDialog(LibraryService *libraryService,
+                                 QueryWorker    *worker,
+                                 QWidget        *parent = nullptr);
+
+    void startForBook(const QString &bookId);
+
+private slots:
+    void onDetailsCompleted(quint64 requestId, const bookhub::gui::BookDetails &details);
+    void onFormatsCompleted(quint64 requestId,
+                            QList<bookhub::gui::BookFormatEntry> formats);
+    void onLanguageSelectionChanged();
+    void onFormatSelectionChanged();
+    void onVoiceSelectionChanged(int voiceId, const QString &voiceName);
+    void onPreviewRequested(int voiceId, const QString &voiceName);
+    void onVoiceUploadRequested();
+    void onBackClicked();
+    void onNextOrGenerateClicked();
+    void onPlayPreview();
+    void onGenerationProgress(int percent);
+    void onGenerationComplete();
+    void onOpenFileClicked();
+    void onAddToLibraryClicked();
+
+private:
+    void buildUi();
+    void resetState();
+    void updateStepUi();
+    void populateLanguageList();
+    void populateFormatList();
+    void populateVoiceList();
+    void requestFormatsForSelectedLanguage();
+    bool startGeneration();
+    void setLibraryStatus(const QString &status);
+    BookSourceEntry selectedSource() const;
+    void showErrorState(const QString &message);
+
+    LibraryService        *m_libraryService{};
+    BookDetailsService    *m_detailsService{};
+    QueryWorker           *m_worker{};
+
+    QString m_bookId;
+    QString m_bookTitle;
+    int     m_libraryItemId{0};
+    QList<BookEditionEntry> m_editions;
+    QList<BookFormatEntry>  m_formats;
+    bool    m_hasLanguageStep{false};
+
+    quint64 m_pendingDetailsId{0};
+    quint64 m_pendingFormatsId{0};
+
+    int     m_currentStep{0}; // 0=language, 1=format, 2=voice, 3=preview, 4=generate
+
+    QString m_selectedLanguage;
+    QString m_selectedFormat;
+    int     m_selectedVoiceId{-1};
+    QString m_selectedVoiceName;
+
+    QLabel               *m_titleLabel{};
+    QLabel               *m_stepLabel{};
+    StepIndicatorWidget  *m_stepIndicator{};
+    QStackedWidget       *m_stepsContainer{};
+    QWidget              *m_progressContainer{};
+    QProgressBar         *m_progressBar{};
+    QLabel               *m_progressText{};
+    QLabel               *m_resultLabel{};
+    QPushButton          *m_backBtn{};
+    QPushButton          *m_nextBtn{};
+
+    // Step widgets (will be allocated in buildUi)
+    QListWidget *m_languageList{};
+    QListWidget *m_formatList{};
+    VoiceSelectorWidget *m_voiceSelector{};
+    MiniAudioPlayerWidget *m_previewPlayer{};
+    QLabel *m_previewText{};
+
+    VoiceUploadDialog *m_uploadDialog{};
+};
+
+} // namespace bookhub::gui

--- a/src/gui/dialogs/voice_upload_dialog.cpp
+++ b/src/gui/dialogs/voice_upload_dialog.cpp
@@ -6,8 +6,6 @@
 #include <QPushButton>
 #include <QFileDialog>
 #include <QFileInfo>
-#include <QMessageBox>
-#include <QDateTime>
 
 namespace bookhub::gui {
 
@@ -107,23 +105,8 @@ void VoiceUploadDialog::onChooseFileClicked()
 
 void VoiceUploadDialog::onValidateClicked()
 {
-    if (!m_selectedFile.isEmpty() && !m_voiceNameEdit->text().isEmpty() && m_isFileValid) {
-        accept();
-    } else {
-        QString error;
-        if (m_selectedFile.isEmpty()) {
-            error = "Please select a file";
-        } else if (m_voiceNameEdit->text().isEmpty()) {
-            error = "Please enter a voice name";
-        } else if (!m_isFormatValid) {
-            error = "File format is not supported (use .wav, .mp3, or .flac)";
-        } else if (!m_isDurationValid) {
-            error = "Audio duration must be between 10 and 120 seconds";
-        }
-        if (!error.isEmpty()) {
-            QMessageBox::warning(this, "Validation Failed", error);
-        }
-    }
+    // Button is only enabled when file is valid and name is non-empty (updateValidateButton).
+    accept();
 }
 
 void VoiceUploadDialog::onFileSelected(const QString &filePath)

--- a/src/gui/dialogs/voice_upload_dialog.cpp
+++ b/src/gui/dialogs/voice_upload_dialog.cpp
@@ -1,0 +1,160 @@
+#include "voice_upload_dialog.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QFileDialog>
+#include <QFileInfo>
+
+namespace bookhub::gui {
+
+VoiceUploadDialog::VoiceUploadDialog(QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle("Upload Voice Sample");
+    setModal(true);
+    setMinimumWidth(400);
+    buildUi();
+}
+
+QString VoiceUploadDialog::selectedFilePath() const
+{
+    return m_selectedFile;
+}
+
+QString VoiceUploadDialog::voiceName() const
+{
+    return m_voiceNameEdit->text();
+}
+
+void VoiceUploadDialog::buildUi()
+{
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+
+    // File selection
+    QLabel *fileLabel = new QLabel("Select a recording of your voice:", this);
+    mainLayout->addWidget(fileLabel);
+
+    QHBoxLayout *fileLayout = new QHBoxLayout();
+    m_chooseFileBtn = new QPushButton("Choose file", this);
+    connect(m_chooseFileBtn, &QPushButton::clicked, this, &VoiceUploadDialog::onChooseFileClicked);
+    fileLayout->addWidget(m_chooseFileBtn);
+
+    m_fileLabel = new QLineEdit(this);
+    m_fileLabel->setReadOnly(true);
+    m_fileLabel->setPlaceholderText("no file selected");
+    fileLayout->addWidget(m_fileLabel);
+    mainLayout->addLayout(fileLayout);
+
+    QLabel *supportedLabel = new QLabel("Supported: .wav, .mp3, .flac", this);
+    supportedLabel->setStyleSheet("color: #6B7280; font-size: 11px;");
+    mainLayout->addWidget(supportedLabel);
+
+    QLabel *durationHint = new QLabel("Duration: 10–120 seconds", this);
+    durationHint->setStyleSheet("color: #6B7280; font-size: 11px;");
+    mainLayout->addWidget(durationHint);
+
+    // Voice name
+    mainLayout->addSpacing(12);
+    QLabel *nameLabel = new QLabel("Voice name:", this);
+    mainLayout->addWidget(nameLabel);
+
+    m_voiceNameEdit = new QLineEdit(this);
+    m_voiceNameEdit->setPlaceholderText("e.g., My Voice");
+    mainLayout->addWidget(m_voiceNameEdit);
+
+    // Validate button
+    m_validateBtn = new QPushButton("Validate & Upload", this);
+    m_validateBtn->setEnabled(false);
+    connect(m_validateBtn, &QPushButton::clicked, this, &VoiceUploadDialog::onValidateClicked);
+    mainLayout->addWidget(m_validateBtn);
+
+    // Validation feedback
+    mainLayout->addSpacing(12);
+    m_durationLabel = new QLabel("○ Duration: checking…", this);
+    m_durationLabel->setStyleSheet("color: #6B7280; font-size: 11px;");
+    mainLayout->addWidget(m_durationLabel);
+
+    m_formatLabel = new QLabel("○ Format: checking…", this);
+    m_formatLabel->setStyleSheet("color: #6B7280; font-size: 11px;");
+    mainLayout->addWidget(m_formatLabel);
+
+    m_qualityLabel = new QLabel("○ Quality: checking…", this);
+    m_qualityLabel->setStyleSheet("color: #6B7280; font-size: 11px;");
+    mainLayout->addWidget(m_qualityLabel);
+
+    mainLayout->addStretch();
+}
+
+void VoiceUploadDialog::onChooseFileClicked()
+{
+    QString fileName = QFileDialog::getOpenFileName(
+        this,
+        "Select Voice Sample",
+        QString(),
+        "Audio files (*.wav *.mp3 *.flac);;All files (*)"
+    );
+
+    if (!fileName.isEmpty()) {
+        onFileSelected(fileName);
+    }
+}
+
+void VoiceUploadDialog::onValidateClicked()
+{
+    if (!m_selectedFile.isEmpty() && !m_voiceNameEdit->text().isEmpty()) {
+        accept();
+    }
+}
+
+void VoiceUploadDialog::onFileSelected(const QString &filePath)
+{
+    m_selectedFile = filePath;
+    QFileInfo fileInfo(filePath);
+    m_fileLabel->setText(fileInfo.fileName());
+    validateFile(filePath);
+    m_validateBtn->setEnabled(!m_voiceNameEdit->text().isEmpty());
+}
+
+void VoiceUploadDialog::validateFile(const QString &filePath)
+{
+    QFileInfo fileInfo(filePath);
+    QString suffix = fileInfo.suffix().toLower();
+
+    // Format validation
+    bool validFormat = (suffix == "wav" || suffix == "mp3" || suffix == "flac");
+    if (validFormat) {
+        m_formatLabel->setText("✓ Format: " + suffix.toUpper() + " (OK)");
+        m_formatLabel->setStyleSheet("color: #16A34A; font-size: 11px; font-weight: bold;");
+    } else {
+        m_formatLabel->setText("✗ Format: invalid");
+        m_formatLabel->setStyleSheet("color: #DC2626; font-size: 11px; font-weight: bold;");
+    }
+
+    // Duration validation (MVP: placeholder)
+    int duration = getAudioFileDuration(filePath);
+    if (duration >= 10 && duration <= 120) {
+        m_durationLabel->setText(QString("✓ Duration: %1 s (OK)").arg(duration));
+        m_durationLabel->setStyleSheet("color: #16A34A; font-size: 11px; font-weight: bold;");
+    } else {
+        m_durationLabel->setText(QString("✗ Duration: %1 s (must be 10–120)").arg(duration));
+        m_durationLabel->setStyleSheet("color: #DC2626; font-size: 11px; font-weight: bold;");
+    }
+
+    // Quality: placeholder for MVP
+    m_qualityLabel->setText("○ Quality: placeholder for Phase 4");
+    m_qualityLabel->setStyleSheet("color: #6B7280; font-size: 11px;");
+}
+
+int VoiceUploadDialog::getAudioFileDuration(const QString &filePath) const
+{
+    // MVP placeholder: return a mock duration based on file size
+    // In Phase 3+, use Qt Multimedia to actually read duration
+    QFileInfo fileInfo(filePath);
+    qint64 fileSize = fileInfo.size();
+    // Rough estimate: ~200KB per second at standard bitrate
+    return static_cast<int>((fileSize / 200000) + 1);
+}
+
+} // namespace bookhub::gui

--- a/src/gui/dialogs/voice_upload_dialog.cpp
+++ b/src/gui/dialogs/voice_upload_dialog.cpp
@@ -149,16 +149,10 @@ void VoiceUploadDialog::validateFile(const QString &filePath)
         m_formatLabel->setStyleSheet("color: #DC2626; font-size: 11px; font-weight: bold;");
     }
 
-    // Duration validation (MVP: placeholder)
-    int duration = getAudioFileDuration(filePath);
-    m_isDurationValid = (duration >= 10 && duration <= 120);
-    if (m_isDurationValid) {
-        m_durationLabel->setText(QString("✓ Duration: %1 s (OK)").arg(duration));
-        m_durationLabel->setStyleSheet("color: #16A34A; font-size: 11px; font-weight: bold;");
-    } else {
-        m_durationLabel->setText(QString("✗ Duration: %1 s (must be 10–120)").arg(duration));
-        m_durationLabel->setStyleSheet("color: #DC2626; font-size: 11px; font-weight: bold;");
-    }
+    // Duration validation (MVP: not implemented — deferred to Phase 3)
+    m_isDurationValid = true;
+    m_durationLabel->setText("○ Duration: not checked in MVP");
+    m_durationLabel->setStyleSheet("color: #6B7280; font-size: 11px;");
 
     // Quality: placeholder for MVP
     m_qualityLabel->setText("○ Quality: placeholder for Phase 4");

--- a/src/gui/dialogs/voice_upload_dialog.cpp
+++ b/src/gui/dialogs/voice_upload_dialog.cpp
@@ -170,7 +170,7 @@ void VoiceUploadDialog::validateFile(const QString &filePath)
     // Quality: placeholder for MVP
     m_qualityLabel->setText("○ Quality: placeholder for Phase 4");
     m_qualityLabel->setStyleSheet("color: #6B7280; font-size: 11px;");
-    
+
     // Update file validity flag
     m_isFileValid = m_isFormatValid && m_isDurationValid;
 }

--- a/src/gui/dialogs/voice_upload_dialog.cpp
+++ b/src/gui/dialogs/voice_upload_dialog.cpp
@@ -43,10 +43,10 @@ void VoiceUploadDialog::buildUi()
     connect(m_chooseFileBtn, &QPushButton::clicked, this, &VoiceUploadDialog::onChooseFileClicked);
     fileLayout->addWidget(m_chooseFileBtn);
 
-    m_fileLabel = new QLineEdit(this);
-    m_fileLabel->setReadOnly(true);
-    m_fileLabel->setPlaceholderText("no file selected");
-    fileLayout->addWidget(m_fileLabel);
+    m_filePathDisplay = new QLineEdit(this);
+    m_filePathDisplay->setReadOnly(true);
+    m_filePathDisplay->setPlaceholderText("no file selected");
+    fileLayout->addWidget(m_filePathDisplay);
     mainLayout->addLayout(fileLayout);
 
     QLabel *supportedLabel = new QLabel("Supported: .wav, .mp3, .flac", this);
@@ -129,7 +129,7 @@ void VoiceUploadDialog::onFileSelected(const QString &filePath)
     m_selectedFile = filePath;
     m_isFileValid = false;  // Reset until validation completes
     QFileInfo fileInfo(filePath);
-    m_fileLabel->setText(fileInfo.fileName());
+    m_filePathDisplay->setText(fileInfo.fileName());
     validateFile(filePath);
     m_validateBtn->setEnabled(!m_voiceNameEdit->text().isEmpty() && m_isFileValid);
 }
@@ -168,14 +168,12 @@ void VoiceUploadDialog::validateFile(const QString &filePath)
     m_isFileValid = m_isFormatValid && m_isDurationValid;
 }
 
-int VoiceUploadDialog::getAudioFileDuration(const QString &filePath) const
+int VoiceUploadDialog::getAudioFileDuration([[maybe_unused]] const QString &filePath) const
 {
-    // MVP placeholder: return a mock duration based on file size
-    // In Phase 3+, use Qt Multimedia to actually read duration
-    QFileInfo fileInfo(filePath);
-    qint64 fileSize = fileInfo.size();
-    // Rough estimate: ~200KB per second at standard bitrate
-    return static_cast<int>((fileSize / 200000) + 1);
+    // Phase 3+: use Qt Multimedia to read actual duration.
+    // Return a value within the accepted range so format-valid files are not
+    // falsely rejected while real duration checking is unavailable.
+    return 60;
 }
 
 } // namespace bookhub::gui

--- a/src/gui/dialogs/voice_upload_dialog.cpp
+++ b/src/gui/dialogs/voice_upload_dialog.cpp
@@ -6,6 +6,8 @@
 #include <QPushButton>
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QMessageBox>
+#include <QDateTime>
 
 namespace bookhub::gui {
 
@@ -103,18 +105,33 @@ void VoiceUploadDialog::onChooseFileClicked()
 
 void VoiceUploadDialog::onValidateClicked()
 {
-    if (!m_selectedFile.isEmpty() && !m_voiceNameEdit->text().isEmpty()) {
+    if (!m_selectedFile.isEmpty() && !m_voiceNameEdit->text().isEmpty() && m_isFileValid) {
         accept();
+    } else {
+        QString error;
+        if (m_selectedFile.isEmpty()) {
+            error = "Please select a file";
+        } else if (m_voiceNameEdit->text().isEmpty()) {
+            error = "Please enter a voice name";
+        } else if (!m_isFormatValid) {
+            error = "File format is not supported (use .wav, .mp3, or .flac)";
+        } else if (!m_isDurationValid) {
+            error = "Audio duration must be between 10 and 120 seconds";
+        }
+        if (!error.isEmpty()) {
+            QMessageBox::warning(this, "Validation Failed", error);
+        }
     }
 }
 
 void VoiceUploadDialog::onFileSelected(const QString &filePath)
 {
     m_selectedFile = filePath;
+    m_isFileValid = false;  // Reset until validation completes
     QFileInfo fileInfo(filePath);
     m_fileLabel->setText(fileInfo.fileName());
     validateFile(filePath);
-    m_validateBtn->setEnabled(!m_voiceNameEdit->text().isEmpty());
+    m_validateBtn->setEnabled(!m_voiceNameEdit->text().isEmpty() && m_isFileValid);
 }
 
 void VoiceUploadDialog::validateFile(const QString &filePath)
@@ -123,8 +140,8 @@ void VoiceUploadDialog::validateFile(const QString &filePath)
     QString suffix = fileInfo.suffix().toLower();
 
     // Format validation
-    bool validFormat = (suffix == "wav" || suffix == "mp3" || suffix == "flac");
-    if (validFormat) {
+    m_isFormatValid = (suffix == "wav" || suffix == "mp3" || suffix == "flac");
+    if (m_isFormatValid) {
         m_formatLabel->setText("✓ Format: " + suffix.toUpper() + " (OK)");
         m_formatLabel->setStyleSheet("color: #16A34A; font-size: 11px; font-weight: bold;");
     } else {
@@ -134,7 +151,8 @@ void VoiceUploadDialog::validateFile(const QString &filePath)
 
     // Duration validation (MVP: placeholder)
     int duration = getAudioFileDuration(filePath);
-    if (duration >= 10 && duration <= 120) {
+    m_isDurationValid = (duration >= 10 && duration <= 120);
+    if (m_isDurationValid) {
         m_durationLabel->setText(QString("✓ Duration: %1 s (OK)").arg(duration));
         m_durationLabel->setStyleSheet("color: #16A34A; font-size: 11px; font-weight: bold;");
     } else {
@@ -145,6 +163,9 @@ void VoiceUploadDialog::validateFile(const QString &filePath)
     // Quality: placeholder for MVP
     m_qualityLabel->setText("○ Quality: placeholder for Phase 4");
     m_qualityLabel->setStyleSheet("color: #6B7280; font-size: 11px;");
+    
+    // Update file validity flag
+    m_isFileValid = m_isFormatValid && m_isDurationValid;
 }
 
 int VoiceUploadDialog::getAudioFileDuration(const QString &filePath) const

--- a/src/gui/dialogs/voice_upload_dialog.cpp
+++ b/src/gui/dialogs/voice_upload_dialog.cpp
@@ -64,6 +64,8 @@ void VoiceUploadDialog::buildUi()
 
     m_voiceNameEdit = new QLineEdit(this);
     m_voiceNameEdit->setPlaceholderText("e.g., My Voice");
+    connect(m_voiceNameEdit, &QLineEdit::textChanged,
+            this, &VoiceUploadDialog::onVoiceNameChanged);
     mainLayout->addWidget(m_voiceNameEdit);
 
     // Validate button
@@ -127,11 +129,22 @@ void VoiceUploadDialog::onValidateClicked()
 void VoiceUploadDialog::onFileSelected(const QString &filePath)
 {
     m_selectedFile = filePath;
-    m_isFileValid = false;  // Reset until validation completes
+    m_isFileValid = false;
     QFileInfo fileInfo(filePath);
     m_filePathDisplay->setText(fileInfo.fileName());
     validateFile(filePath);
-    m_validateBtn->setEnabled(!m_voiceNameEdit->text().isEmpty() && m_isFileValid);
+    updateValidateButton();
+}
+
+void VoiceUploadDialog::onVoiceNameChanged()
+{
+    updateValidateButton();
+}
+
+void VoiceUploadDialog::updateValidateButton()
+{
+    m_validateBtn->setEnabled(!m_selectedFile.isEmpty() && m_isFileValid
+                              && !m_voiceNameEdit->text().isEmpty());
 }
 
 void VoiceUploadDialog::validateFile(const QString &filePath)
@@ -160,14 +173,6 @@ void VoiceUploadDialog::validateFile(const QString &filePath)
     
     // Update file validity flag
     m_isFileValid = m_isFormatValid && m_isDurationValid;
-}
-
-int VoiceUploadDialog::getAudioFileDuration([[maybe_unused]] const QString &filePath) const
-{
-    // Phase 3+: use Qt Multimedia to read actual duration.
-    // Return a value within the accepted range so format-valid files are not
-    // falsely rejected while real duration checking is unavailable.
-    return 60;
 }
 
 } // namespace bookhub::gui

--- a/src/gui/dialogs/voice_upload_dialog.h
+++ b/src/gui/dialogs/voice_upload_dialog.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QDialog>
+
+class QLineEdit;
+class QPushButton;
+class QLabel;
+
+namespace bookhub::gui {
+
+class VoiceUploadDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit VoiceUploadDialog(QWidget *parent = nullptr);
+
+    QString selectedFilePath() const;
+    QString voiceName() const;
+
+private slots:
+    void onChooseFileClicked();
+    void onValidateClicked();
+    void onFileSelected(const QString &filePath);
+
+private:
+    void buildUi();
+    void validateFile(const QString &filePath);
+    int getAudioFileDuration(const QString &filePath) const;
+
+    QString m_selectedFile;
+    QLineEdit *m_fileLabel{};
+    QLineEdit *m_voiceNameEdit{};
+    QPushButton *m_chooseFileBtn{};
+    QPushButton *m_validateBtn{};
+    QLabel *m_durationLabel{};
+    QLabel *m_formatLabel{};
+    QLabel *m_qualityLabel{};
+};
+
+} // namespace bookhub::gui

--- a/src/gui/dialogs/voice_upload_dialog.h
+++ b/src/gui/dialogs/voice_upload_dialog.h
@@ -32,7 +32,7 @@ private:
     bool m_isFileValid{false};
     bool m_isDurationValid{false};
     bool m_isFormatValid{false};
-    
+
     QLineEdit *m_filePathDisplay{};
     QLineEdit *m_voiceNameEdit{};
     QPushButton *m_chooseFileBtn{};

--- a/src/gui/dialogs/voice_upload_dialog.h
+++ b/src/gui/dialogs/voice_upload_dialog.h
@@ -28,6 +28,10 @@ private:
     int getAudioFileDuration(const QString &filePath) const;
 
     QString m_selectedFile;
+    bool m_isFileValid{false};
+    bool m_isDurationValid{false};
+    bool m_isFormatValid{false};
+    
     QLineEdit *m_fileLabel{};
     QLineEdit *m_voiceNameEdit{};
     QPushButton *m_chooseFileBtn{};

--- a/src/gui/dialogs/voice_upload_dialog.h
+++ b/src/gui/dialogs/voice_upload_dialog.h
@@ -21,11 +21,12 @@ private slots:
     void onChooseFileClicked();
     void onValidateClicked();
     void onFileSelected(const QString &filePath);
+    void onVoiceNameChanged();
 
 private:
     void buildUi();
     void validateFile(const QString &filePath);
-    int getAudioFileDuration(const QString &filePath) const;
+    void updateValidateButton();
 
     QString m_selectedFile;
     bool m_isFileValid{false};

--- a/src/gui/dialogs/voice_upload_dialog.h
+++ b/src/gui/dialogs/voice_upload_dialog.h
@@ -32,7 +32,7 @@ private:
     bool m_isDurationValid{false};
     bool m_isFormatValid{false};
     
-    QLineEdit *m_fileLabel{};
+    QLineEdit *m_filePathDisplay{};
     QLineEdit *m_voiceNameEdit{};
     QPushButton *m_chooseFileBtn{};
     QPushButton *m_validateBtn{};

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -1,4 +1,5 @@
 #include "main_window.h"
+#include "dialogs/audiobook_flow_dialog.h"
 #include "dialogs/download_flow_dialog.h"
 #include "panels/book_details_panel.h"
 #include "query_worker.h"
@@ -111,8 +112,11 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
           this, &MainWindow::onBookDetailsDismissed);
   connect(m_bookDetailsPanel, &BookDetailsPanel::downloadRequested,
           this, &MainWindow::onDownloadRequested);
+  connect(m_bookDetailsPanel, &BookDetailsPanel::audiobookRequested,
+          this, &MainWindow::onAudiobookRequested);
 
   m_downloadDialog = new DownloadFlowDialog(m_libraryService, m_queryWorker, this);
+  m_audiobookDialog = new AudiobookFlowDialog(m_libraryService, m_queryWorker, this);
 
   // Status bar
   buildStatusBar();
@@ -262,6 +266,11 @@ void MainWindow::onBookDetailsDismissed() {
 
 void MainWindow::onDownloadRequested(const QString &bookId) {
   m_downloadDialog->startForBook(bookId);
+}
+
+void MainWindow::onAudiobookRequested(const QString &bookId) {
+  m_audiobookDialog->startForBook(bookId);
+  m_audiobookDialog->exec();
 }
 
 } // namespace bookhub::gui

--- a/src/gui/main_window.h
+++ b/src/gui/main_window.h
@@ -13,6 +13,7 @@ namespace bookhub::gui {
 
 class BookDetailsPanel;
 class DownloadFlowDialog;
+class AudiobookFlowDialog;
 class ExploreScreen;
 class LibraryScreen;
 class LibraryService;
@@ -48,6 +49,7 @@ private slots:
     void onBookDetailsRequested(const QString &bookId);
     void onBookDetailsDismissed();
     void onDownloadRequested(const QString &bookId);
+    void onAudiobookRequested(const QString &bookId);
 
 private:
     friend class ::MainWindowTest;
@@ -69,6 +71,7 @@ private:
     ExploreScreen     *m_exploreScreen{};
     BookDetailsPanel  *m_bookDetailsPanel{};
     DownloadFlowDialog *m_downloadDialog{};
+    AudiobookFlowDialog *m_audiobookDialog{};
 
     // Status bar widgets
     QLabel *m_statusLabel{};

--- a/src/gui/panels/book_details_panel.cpp
+++ b/src/gui/panels/book_details_panel.cpp
@@ -480,6 +480,7 @@ void BookDetailsPanel::populateDetails(const BookDetails &details)
 
     setLibraryButtonState(m_inLibrary);
     m_downloadBtn->setEnabled(false);
+    m_audiobookBtn->setEnabled(false);
 
     // Clear formats; they'll be loaded by the requestFormatsForEdition call
     // that follows immediately in onDetailsCompleted.
@@ -497,6 +498,7 @@ void BookDetailsPanel::populateFormats(const QList<BookFormatEntry> &formats)
 
     if (formats.isEmpty()) {
         m_downloadBtn->setEnabled(false);
+        m_audiobookBtn->setEnabled(false);
         auto *noFmt = new QLabel(
             QStringLiteral("No downloadable formats available yet."),
             m_formatsWidget);
@@ -508,6 +510,7 @@ void BookDetailsPanel::populateFormats(const QList<BookFormatEntry> &formats)
     }
 
     m_downloadBtn->setEnabled(true);
+    m_audiobookBtn->setEnabled(true);
 
     for (const auto &fmt : formats) {
         auto *row       = new QWidget(m_formatsWidget);

--- a/src/gui/panels/book_details_panel.cpp
+++ b/src/gui/panels/book_details_panel.cpp
@@ -406,8 +406,8 @@ void BookDetailsPanel::buildUi()
 
     m_audiobookBtn = new QPushButton(QStringLiteral("♪ Audiobook"), secondaryRow);
     m_audiobookBtn->setStyleSheet(secondaryStyle);
-    m_audiobookBtn->setToolTip(QStringLiteral("Audiobook conversion — coming soon"));
-    m_audiobookBtn->setEnabled(false); // Task 12
+    m_audiobookBtn->setToolTip(QStringLiteral("Convert this book to an audiobook"));
+    m_audiobookBtn->setEnabled(false);
     connect(m_audiobookBtn, &QPushButton::clicked, this,
             [this] { emit audiobookRequested(m_currentBookId); });
     secondaryLayout->addWidget(m_audiobookBtn);

--- a/src/gui/query_worker.cpp
+++ b/src/gui/query_worker.cpp
@@ -4,7 +4,6 @@
 #include "services/explore_service.h"
 #include "services/library_service.h"
 #include "services/search_service.h"
-#include "services/tts_service.h"
 
 #include <QSqlDatabase>
 #include <QSqlError>
@@ -271,7 +270,7 @@ bool deleteVoice(int voiceId, const QString &connectionName)
         qWarning() << "internal::deleteVoice failed:" << query.lastError().text();
         return false;
     }
-    return true;
+    return query.numRowsAffected() > 0;
 }
 
 bool queryAudiobookStatus(const QString &bookId, bool &outIsReady, const QString &connectionName)

--- a/src/gui/query_worker.cpp
+++ b/src/gui/query_worker.cpp
@@ -265,7 +265,7 @@ void QueryWorker::handleSetAudiobookReadyRequest(quint64 requestId, const QStrin
     ));
     query.addBindValue(bookId);
 
-    bool success = query.exec();
+    bool success = query.exec() && query.numRowsAffected() > 0;
     if (!success) {
         qWarning() << "handleSetAudiobookReadyRequest failed:" << query.lastError().text();
     }

--- a/src/gui/query_worker.cpp
+++ b/src/gui/query_worker.cpp
@@ -162,77 +162,26 @@ void QueryWorker::handleFormatsForEditionRequest(quint64 requestId, int editionI
 
 void QueryWorker::handleListVoicesRequest(quint64 requestId)
 {
-    QSqlQuery query(QSqlDatabase::database(conn()));
-    const QString sql = QStringLiteral(
-        "SELECT id, voice_name, is_preset FROM voices ORDER BY is_preset DESC, voice_name"
-    );
-
-    QList<VoiceEntry> voices;
-    if (!query.exec(sql)) {
-        qWarning() << "handleListVoicesRequest failed:" << query.lastError().text();
-    } else {
-        while (query.next()) {
-            VoiceEntry entry;
-            entry.id = query.value(0).toInt();
-            entry.name = query.value(1).toString();
-            entry.isPreset = query.value(2).toInt() != 0;
-            voices.append(entry);
-        }
-    }
-    emit listVoicesCompleted(requestId, voices);
+    emit listVoicesCompleted(requestId, internal::listVoices(conn()));
 }
 
 void QueryWorker::handleInsertVoiceRequest(quint64 requestId, const QString &voiceName,
                                            const QString &voiceType, bool isPreset)
 {
-    QSqlQuery query(QSqlDatabase::database(conn()));
-    query.prepare(QStringLiteral(
-        "INSERT INTO voices (voice_name, voice_type, is_preset) VALUES (?, ?, ?)"
-    ));
-    query.addBindValue(voiceName);
-    query.addBindValue(voiceType);
-    query.addBindValue(isPreset ? 1 : 0);
-
-    bool success = query.exec();
     int newId = -1;
-    if (success) {
-        newId = query.lastInsertId().toInt();
-    } else {
-        qWarning() << "handleInsertVoiceRequest failed:" << query.lastError().text();
-    }
-    emit insertVoiceCompleted(requestId, success, newId);
+    const bool ok = internal::insertVoice(voiceName, voiceType, isPreset, &newId, conn());
+    emit insertVoiceCompleted(requestId, ok, newId);
 }
 
 void QueryWorker::handleUpdateVoiceRequest(quint64 requestId, int voiceId,
                                            const QString &voiceType)
 {
-    QSqlQuery query(QSqlDatabase::database(conn()));
-    query.prepare(QStringLiteral(
-        "UPDATE voices SET voice_type = ? WHERE id = ?"
-    ));
-    query.addBindValue(voiceType);
-    query.addBindValue(voiceId);
-
-    bool success = query.exec();
-    if (!success) {
-        qWarning() << "handleUpdateVoiceRequest failed:" << query.lastError().text();
-    }
-    emit updateVoiceCompleted(requestId, success);
+    emit updateVoiceCompleted(requestId, internal::updateVoice(voiceId, voiceType, conn()));
 }
 
 void QueryWorker::handleDeleteVoiceRequest(quint64 requestId, int voiceId)
 {
-    QSqlQuery query(QSqlDatabase::database(conn()));
-    query.prepare(QStringLiteral(
-        "DELETE FROM voices WHERE id = ?"
-    ));
-    query.addBindValue(voiceId);
-
-    bool success = query.exec();
-    if (!success) {
-        qWarning() << "handleDeleteVoiceRequest failed:" << query.lastError().text();
-    }
-    emit deleteVoiceCompleted(requestId, success);
+    emit deleteVoiceCompleted(requestId, internal::deleteVoice(voiceId, conn()));
 }
 
 // ---------------------------------------------------------------------------
@@ -241,35 +190,110 @@ void QueryWorker::handleDeleteVoiceRequest(quint64 requestId, int voiceId)
 
 void QueryWorker::handleQueryAudiobookStatusRequest(quint64 requestId, const QString &bookId)
 {
-    QSqlQuery query(QSqlDatabase::database(conn()));
-    query.prepare(QStringLiteral(
-        "SELECT status FROM library_items WHERE book_id = ? LIMIT 1"
-    ));
-    query.addBindValue(bookId);
-
     bool isReady = false;
-    if (query.exec() && query.next()) {
-        QString status = query.value(0).toString();
-        isReady = (status == QLatin1String("audiobook_ready"));
-    } else {
-        qWarning() << "handleQueryAudiobookStatusRequest failed:" << query.lastError().text();
-    }
+    if (!internal::queryAudiobookStatus(bookId, isReady, conn()))
+        qWarning() << "handleQueryAudiobookStatusRequest failed for book_id:" << bookId;
     emit audiobookStatusQueried(requestId, isReady);
 }
 
 void QueryWorker::handleSetAudiobookReadyRequest(quint64 requestId, const QString &bookId)
 {
-    QSqlQuery query(QSqlDatabase::database(conn()));
-    query.prepare(QStringLiteral(
-        "UPDATE library_items SET status = 'audiobook_ready' WHERE book_id = ?"
-    ));
-    query.addBindValue(bookId);
-
-    bool success = query.exec() && query.numRowsAffected() > 0;
-    if (!success) {
-        qWarning() << "handleSetAudiobookReadyRequest failed:" << query.lastError().text();
-    }
+    const bool success = internal::setAudiobookReady(bookId, conn());
+    if (!success)
+        qWarning() << "handleSetAudiobookReadyRequest: no matching library_items row for book_id:" << bookId;
     emit audiobookReadySet(requestId, success);
 }
+
+// ---------------------------------------------------------------------------
+// Internal free functions — voice and audiobook-status SQL
+// ---------------------------------------------------------------------------
+
+namespace internal {
+
+QList<VoiceEntry> listVoices(const QString &connectionName)
+{
+    QSqlQuery query(QSqlDatabase::database(connectionName));
+    QList<VoiceEntry> voices;
+    if (!query.exec(QStringLiteral(
+            "SELECT id, voice_name, is_preset FROM voices ORDER BY is_preset DESC, voice_name"))) {
+        qWarning() << "internal::listVoices failed:" << query.lastError().text();
+        return voices;
+    }
+    while (query.next()) {
+        VoiceEntry entry;
+        entry.id      = query.value(0).toInt();
+        entry.name    = query.value(1).toString();
+        entry.isPreset = query.value(2).toInt() != 0;
+        voices.append(entry);
+    }
+    return voices;
+}
+
+bool insertVoice(const QString &voiceName, const QString &voiceType, bool isPreset,
+                 int *outNewId, const QString &connectionName)
+{
+    QSqlQuery query(QSqlDatabase::database(connectionName));
+    query.prepare(QStringLiteral(
+        "INSERT INTO voices (voice_name, voice_type, is_preset) VALUES (?, ?, ?)"));
+    query.addBindValue(voiceName);
+    query.addBindValue(voiceType);
+    query.addBindValue(isPreset ? 1 : 0);
+    if (!query.exec()) {
+        qWarning() << "internal::insertVoice failed:" << query.lastError().text();
+        return false;
+    }
+    if (outNewId)
+        *outNewId = query.lastInsertId().toInt();
+    return true;
+}
+
+bool updateVoice(int voiceId, const QString &voiceType, const QString &connectionName)
+{
+    QSqlQuery query(QSqlDatabase::database(connectionName));
+    query.prepare(QStringLiteral("UPDATE voices SET voice_type = ? WHERE id = ?"));
+    query.addBindValue(voiceType);
+    query.addBindValue(voiceId);
+    if (!query.exec()) {
+        qWarning() << "internal::updateVoice failed:" << query.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+bool deleteVoice(int voiceId, const QString &connectionName)
+{
+    QSqlQuery query(QSqlDatabase::database(connectionName));
+    query.prepare(QStringLiteral("DELETE FROM voices WHERE id = ?"));
+    query.addBindValue(voiceId);
+    if (!query.exec()) {
+        qWarning() << "internal::deleteVoice failed:" << query.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+bool queryAudiobookStatus(const QString &bookId, bool &outIsReady, const QString &connectionName)
+{
+    QSqlQuery query(QSqlDatabase::database(connectionName));
+    query.prepare(QStringLiteral(
+        "SELECT status FROM library_items WHERE book_id = ? LIMIT 1"));
+    query.addBindValue(bookId);
+    if (!query.exec())
+        return false;
+    outIsReady = query.next()
+        && (query.value(0).toString() == QLatin1String("audiobook_ready"));
+    return true;
+}
+
+bool setAudiobookReady(const QString &bookId, const QString &connectionName)
+{
+    QSqlQuery query(QSqlDatabase::database(connectionName));
+    query.prepare(QStringLiteral(
+        "UPDATE library_items SET status = 'audiobook_ready' WHERE book_id = ?"));
+    query.addBindValue(bookId);
+    return query.exec() && query.numRowsAffected() > 0;
+}
+
+} // namespace internal
 
 } // namespace bookhub::gui

--- a/src/gui/query_worker.cpp
+++ b/src/gui/query_worker.cpp
@@ -7,6 +7,7 @@
 
 #include <QSqlDatabase>
 #include <QSqlError>
+#include <QSqlQuery>
 #include <QDebug>
 
 #include <utility>
@@ -153,6 +154,122 @@ void QueryWorker::handleFormatsForEditionRequest(quint64 requestId, int editionI
 {
     emit formatsForEditionCompleted(requestId,
         internal::fetchFormatsForEdition(editionId, conn()));
+}
+
+// ---------------------------------------------------------------------------
+// Voice CRUD handlers
+// ---------------------------------------------------------------------------
+
+void QueryWorker::handleListVoicesRequest(quint64 requestId)
+{
+    QSqlQuery query(QSqlDatabase::database(conn()));
+    const QString sql = QStringLiteral(
+        "SELECT id, voice_name, is_preset FROM voices ORDER BY is_preset DESC, voice_name"
+    );
+
+    QList<VoiceEntry> voices;
+    if (!query.exec(sql)) {
+        qWarning() << "handleListVoicesRequest failed:" << query.lastError().text();
+    } else {
+        while (query.next()) {
+            VoiceEntry entry;
+            entry.id = query.value(0).toInt();
+            entry.name = query.value(1).toString();
+            entry.isPreset = query.value(2).toInt() != 0;
+            voices.append(entry);
+        }
+    }
+    emit listVoicesCompleted(requestId, voices);
+}
+
+void QueryWorker::handleInsertVoiceRequest(quint64 requestId, const QString &voiceName,
+                                           const QString &voiceType, bool isPreset)
+{
+    QSqlQuery query(QSqlDatabase::database(conn()));
+    query.prepare(QStringLiteral(
+        "INSERT INTO voices (voice_name, voice_type, is_preset) VALUES (?, ?, ?)"
+    ));
+    query.addBindValue(voiceName);
+    query.addBindValue(voiceType);
+    query.addBindValue(isPreset ? 1 : 0);
+
+    bool success = query.exec();
+    int newId = -1;
+    if (success) {
+        newId = query.lastInsertId().toInt();
+    } else {
+        qWarning() << "handleInsertVoiceRequest failed:" << query.lastError().text();
+    }
+    emit insertVoiceCompleted(requestId, success, newId);
+}
+
+void QueryWorker::handleUpdateVoiceRequest(quint64 requestId, int voiceId,
+                                           const QString &voiceType)
+{
+    QSqlQuery query(QSqlDatabase::database(conn()));
+    query.prepare(QStringLiteral(
+        "UPDATE voices SET voice_type = ? WHERE id = ?"
+    ));
+    query.addBindValue(voiceType);
+    query.addBindValue(voiceId);
+
+    bool success = query.exec();
+    if (!success) {
+        qWarning() << "handleUpdateVoiceRequest failed:" << query.lastError().text();
+    }
+    emit updateVoiceCompleted(requestId, success);
+}
+
+void QueryWorker::handleDeleteVoiceRequest(quint64 requestId, int voiceId)
+{
+    QSqlQuery query(QSqlDatabase::database(conn()));
+    query.prepare(QStringLiteral(
+        "DELETE FROM voices WHERE id = ?"
+    ));
+    query.addBindValue(voiceId);
+
+    bool success = query.exec();
+    if (!success) {
+        qWarning() << "handleDeleteVoiceRequest failed:" << query.lastError().text();
+    }
+    emit deleteVoiceCompleted(requestId, success);
+}
+
+// ---------------------------------------------------------------------------
+// Audiobook status handlers
+// ---------------------------------------------------------------------------
+
+void QueryWorker::handleQueryAudiobookStatusRequest(quint64 requestId, const QString &bookId)
+{
+    QSqlQuery query(QSqlDatabase::database(conn()));
+    query.prepare(QStringLiteral(
+        "SELECT status FROM library_items WHERE book_id = ? LIMIT 1"
+    ));
+    query.addBindValue(bookId);
+
+    bool isReady = false;
+    if (query.exec() && query.next()) {
+        QString status = query.value(0).toString();
+        isReady = (status == QLatin1String("audiobook_ready"));
+    } else {
+        qWarning() << "handleQueryAudiobookStatusRequest failed:" << query.lastError().text();
+    }
+    emit audiobookStatusQueried(requestId, isReady);
+}
+
+void QueryWorker::handleSetAudiobookReadyRequest(quint64 requestId, const QString &bookId)
+{
+    QSqlQuery query(QSqlDatabase::database(conn()));
+    query.prepare(QStringLiteral(
+        "UPDATE library_items SET status = 'audiobook_ready' WHERE book_id = ?"
+    ));
+    query.addBindValue(bookId);
+
+    bool success = query.exec();
+    if (!success) {
+        qWarning() << "handleSetAudiobookReadyRequest failed:" << query.lastError().text();
+    }
+    emit audiobookReadySet(requestId, success);
 }
 
 } // namespace bookhub::gui

--- a/src/gui/query_worker.cpp
+++ b/src/gui/query_worker.cpp
@@ -259,7 +259,7 @@ bool updateVoice(int voiceId, const QString &engine, const QString &connectionNa
         qWarning() << "internal::updateVoice failed:" << query.lastError().text();
         return false;
     }
-    return true;
+    return query.numRowsAffected() > 0;
 }
 
 bool deleteVoice(int voiceId, const QString &connectionName)

--- a/src/gui/query_worker.cpp
+++ b/src/gui/query_worker.cpp
@@ -4,6 +4,7 @@
 #include "services/explore_service.h"
 #include "services/library_service.h"
 #include "services/search_service.h"
+#include "services/tts_service.h"
 
 #include <QSqlDatabase>
 #include <QSqlError>

--- a/src/gui/query_worker.cpp
+++ b/src/gui/query_worker.cpp
@@ -165,18 +165,18 @@ void QueryWorker::handleListVoicesRequest(quint64 requestId)
     emit listVoicesCompleted(requestId, internal::listVoices(conn()));
 }
 
-void QueryWorker::handleInsertVoiceRequest(quint64 requestId, const QString &voiceName,
-                                           const QString &voiceType, bool isPreset)
+void QueryWorker::handleInsertVoiceRequest(quint64 requestId, const QString &name,
+                                           const QString &type, const QString &engine)
 {
     int newId = -1;
-    const bool ok = internal::insertVoice(voiceName, voiceType, isPreset, &newId, conn());
+    const bool ok = internal::insertVoice(name, type, engine, &newId, conn());
     emit insertVoiceCompleted(requestId, ok, newId);
 }
 
 void QueryWorker::handleUpdateVoiceRequest(quint64 requestId, int voiceId,
-                                           const QString &voiceType)
+                                           const QString &engine)
 {
-    emit updateVoiceCompleted(requestId, internal::updateVoice(voiceId, voiceType, conn()));
+    emit updateVoiceCompleted(requestId, internal::updateVoice(voiceId, engine, conn()));
 }
 
 void QueryWorker::handleDeleteVoiceRequest(quint64 requestId, int voiceId)
@@ -215,29 +215,30 @@ QList<VoiceEntry> listVoices(const QString &connectionName)
     QSqlQuery query(QSqlDatabase::database(connectionName));
     QList<VoiceEntry> voices;
     if (!query.exec(QStringLiteral(
-            "SELECT id, voice_name, is_preset FROM voices ORDER BY is_preset DESC, voice_name"))) {
+            "SELECT id, name, (type = 'preset') FROM voices"
+            " ORDER BY (type = 'preset') DESC, name"))) {
         qWarning() << "internal::listVoices failed:" << query.lastError().text();
         return voices;
     }
     while (query.next()) {
         VoiceEntry entry;
-        entry.id      = query.value(0).toInt();
-        entry.name    = query.value(1).toString();
+        entry.id       = query.value(0).toInt();
+        entry.name     = query.value(1).toString();
         entry.isPreset = query.value(2).toInt() != 0;
         voices.append(entry);
     }
     return voices;
 }
 
-bool insertVoice(const QString &voiceName, const QString &voiceType, bool isPreset,
+bool insertVoice(const QString &name, const QString &type, const QString &engine,
                  int *outNewId, const QString &connectionName)
 {
     QSqlQuery query(QSqlDatabase::database(connectionName));
     query.prepare(QStringLiteral(
-        "INSERT INTO voices (voice_name, voice_type, is_preset) VALUES (?, ?, ?)"));
-    query.addBindValue(voiceName);
-    query.addBindValue(voiceType);
-    query.addBindValue(isPreset ? 1 : 0);
+        "INSERT INTO voices (name, type, engine) VALUES (?, ?, ?)"));
+    query.addBindValue(name);
+    query.addBindValue(type);
+    query.addBindValue(engine);
     if (!query.exec()) {
         qWarning() << "internal::insertVoice failed:" << query.lastError().text();
         return false;
@@ -247,11 +248,11 @@ bool insertVoice(const QString &voiceName, const QString &voiceType, bool isPres
     return true;
 }
 
-bool updateVoice(int voiceId, const QString &voiceType, const QString &connectionName)
+bool updateVoice(int voiceId, const QString &engine, const QString &connectionName)
 {
     QSqlQuery query(QSqlDatabase::database(connectionName));
-    query.prepare(QStringLiteral("UPDATE voices SET voice_type = ? WHERE id = ?"));
-    query.addBindValue(voiceType);
+    query.prepare(QStringLiteral("UPDATE voices SET engine = ? WHERE id = ?"));
+    query.addBindValue(engine);
     query.addBindValue(voiceId);
     if (!query.exec()) {
         qWarning() << "internal::updateVoice failed:" << query.lastError().text();

--- a/src/gui/query_worker.h
+++ b/src/gui/query_worker.h
@@ -62,9 +62,9 @@ public slots:
 
     // Voice CRUD
     virtual void handleListVoicesRequest(quint64 requestId);
-    virtual void handleInsertVoiceRequest(quint64 requestId, const QString &voiceName,
-                                          const QString &voiceType, bool isPreset);
-    virtual void handleUpdateVoiceRequest(quint64 requestId, int voiceId, const QString &voiceType);
+    virtual void handleInsertVoiceRequest(quint64 requestId, const QString &name,
+                                          const QString &type, const QString &engine);
+    virtual void handleUpdateVoiceRequest(quint64 requestId, int voiceId, const QString &engine);
     virtual void handleDeleteVoiceRequest(quint64 requestId, int voiceId);
 
     // Audiobook operations

--- a/src/gui/query_worker.h
+++ b/src/gui/query_worker.h
@@ -9,6 +9,7 @@
 #include "services/explore_service.h"
 #include "services/library_service.h"
 #include "services/search_service.h"
+#include "widgets/voice_selector_widget.h"
 
 namespace bookhub::gui {
 
@@ -59,6 +60,17 @@ public slots:
     virtual void handleBookDetailsRequest(quint64 requestId, const QString &bookId);
     virtual void handleFormatsForEditionRequest(quint64 requestId, int editionId);
 
+    // Voice CRUD
+    virtual void handleListVoicesRequest(quint64 requestId);
+    virtual void handleInsertVoiceRequest(quint64 requestId, const QString &voiceName,
+                                          const QString &voiceType, bool isPreset);
+    virtual void handleUpdateVoiceRequest(quint64 requestId, int voiceId, const QString &voiceType);
+    virtual void handleDeleteVoiceRequest(quint64 requestId, int voiceId);
+
+    // Audiobook operations
+    virtual void handleQueryAudiobookStatusRequest(quint64 requestId, const QString &bookId);
+    virtual void handleSetAudiobookReadyRequest(quint64 requestId, const QString &bookId);
+
 signals:
     // Search results
     void searchCompleted(quint64 requestId, QList<bookhub::gui::SearchResult> results);
@@ -83,6 +95,16 @@ signals:
     void bookDetailsCompleted(quint64 requestId, bookhub::gui::BookDetails details);
     void formatsForEditionCompleted(quint64 requestId,
                                     QList<bookhub::gui::BookFormatEntry> formats);
+
+    // Voice results
+    void listVoicesCompleted(quint64 requestId, QList<bookhub::gui::VoiceEntry> voices);
+    void insertVoiceCompleted(quint64 requestId, bool success, int newId);
+    void updateVoiceCompleted(quint64 requestId, bool success);
+    void deleteVoiceCompleted(quint64 requestId, bool success);
+
+    // Audiobook status results
+    void audiobookStatusQueried(quint64 requestId, bool isReady);
+    void audiobookReadySet(quint64 requestId, bool success);
 
 private:
     static constexpr const char *kConnectionName = "gui_query_connection";

--- a/src/gui/query_worker.h
+++ b/src/gui/query_worker.h
@@ -9,7 +9,7 @@
 #include "services/explore_service.h"
 #include "services/library_service.h"
 #include "services/search_service.h"
-#include "widgets/voice_selector_widget.h"
+#include "services/tts_types.h"
 
 namespace bookhub::gui {
 

--- a/src/gui/query_worker.h
+++ b/src/gui/query_worker.h
@@ -111,4 +111,20 @@ private:
     static QLatin1String conn() noexcept { return QLatin1String{kConnectionName}; }
 };
 
+// ---------------------------------------------------------------------------
+// Internal free functions for voice and audiobook-status queries.
+// Implemented in query_worker.cpp; called by TestQueryWorker in tests.
+// ---------------------------------------------------------------------------
+namespace internal {
+    QList<VoiceEntry> listVoices(const QString &connectionName);
+    // type must be 'preset' or 'custom'; engine must be 'sherpa_onnx' or 'pocket_tts'.
+    bool insertVoice(const QString &name, const QString &type, const QString &engine,
+                     int *outNewId, const QString &connectionName);
+    bool updateVoice(int voiceId, const QString &engine, const QString &connectionName);
+    bool deleteVoice(int voiceId, const QString &connectionName);
+    bool queryAudiobookStatus(const QString &bookId, bool &outIsReady,
+                              const QString &connectionName);
+    bool setAudiobookReady(const QString &bookId, const QString &connectionName);
+} // namespace internal
+
 } // namespace bookhub::gui

--- a/src/gui/services/library_service.cpp
+++ b/src/gui/services/library_service.cpp
@@ -25,6 +25,12 @@ void LibraryService::connectToWorker(QueryWorker *worker)
     connect(this, &LibraryService::updateStatusRequested,
             worker, &QueryWorker::handleUpdateStatusRequest);
 
+    // Audiobook operations
+    connect(this, &LibraryService::queryAudiobookStatusRequested,
+            worker, &QueryWorker::handleQueryAudiobookStatusRequest);
+    connect(this, &LibraryService::setAudiobookReadyRequested,
+            worker, &QueryWorker::handleSetAudiobookReadyRequest);
+
     connect(worker, &QueryWorker::fetchItemsCompleted, this,
             [this](quint64 id, QList<LibraryItem> items) {
                 Q_ASSERT(m_pendingCount > 0);
@@ -52,6 +58,22 @@ void LibraryService::connectToWorker(QueryWorker *worker)
                 Q_ASSERT(m_pendingCount > 0);
                 --m_pendingCount;
                 emit updateStatusCompleted(id, success);
+                if (success)
+                    emit libraryChanged();
+            });
+
+    // Audiobook status handlers
+    connect(worker, &QueryWorker::audiobookStatusQueried, this,
+            [this](quint64 id, bool isReady) {
+                Q_ASSERT(m_pendingCount > 0);
+                --m_pendingCount;
+                emit audiobookStatusQueried(id, isReady);
+            });
+    connect(worker, &QueryWorker::audiobookReadySet, this,
+            [this](quint64 id, bool success) {
+                Q_ASSERT(m_pendingCount > 0);
+                --m_pendingCount;
+                emit audiobookConversionCompleted(id, success);
                 if (success)
                     emit libraryChanged();
             });
@@ -99,6 +121,22 @@ quint64 LibraryService::requestUpdateStatus(int libraryItemId, const QString &st
     const quint64 id = m_nextRequestId.fetch_add(1, std::memory_order_relaxed);
     ++m_pendingCount;
     emit updateStatusRequested(id, libraryItemId, status);
+    return id;
+}
+
+quint64 LibraryService::requestQueryAudiobookStatus(const QString &bookId)
+{
+    const quint64 id = m_nextRequestId.fetch_add(1, std::memory_order_relaxed);
+    ++m_pendingCount;
+    emit queryAudiobookStatusRequested(id, bookId);
+    return id;
+}
+
+quint64 LibraryService::requestSetAudiobookReady(const QString &bookId)
+{
+    const quint64 id = m_nextRequestId.fetch_add(1, std::memory_order_relaxed);
+    ++m_pendingCount;
+    emit setAudiobookReadyRequested(id, bookId);
     return id;
 }
 

--- a/src/gui/services/library_service.h
+++ b/src/gui/services/library_service.h
@@ -48,12 +48,20 @@ public:
     quint64 requestRemoveBookByBookId(const QString &bookId);
     quint64 requestUpdateStatus(int libraryItemId, const QString &status);
 
+    // Audiobook operations
+    quint64 requestQueryAudiobookStatus(const QString &bookId);
+    quint64 requestSetAudiobookReady(const QString &bookId);
+
 signals:
     // Result signals — delivered on the GUI thread
     void fetchItemsCompleted(quint64 requestId, QList<bookhub::gui::LibraryItem> items);
     void addBookCompleted(quint64 requestId, QString bookId, bool success, int newId);
     void removeBookCompleted(quint64 requestId, QString bookId, bool success);
     void updateStatusCompleted(quint64 requestId, bool success);
+
+    // Audiobook status signals
+    void audiobookStatusQueried(quint64 requestId, bool isReady);
+    void audiobookConversionCompleted(quint64 requestId, bool success);
 
     // Emitted after any successful write so views can refresh
     void libraryChanged();
@@ -64,6 +72,10 @@ signals:
     void removeBookRequested(quint64 requestId, int libraryItemId, QString bookId);
     void removeBookByBookIdRequested(quint64 requestId, QString bookId);
     void updateStatusRequested(quint64 requestId, int libraryItemId, QString status);
+
+    // Audiobook internal signals
+    void queryAudiobookStatusRequested(quint64 requestId, QString bookId);
+    void setAudiobookReadyRequested(quint64 requestId, QString bookId);
 
 private:
     std::atomic<quint64> m_nextRequestId{1};

--- a/src/gui/services/tts_service.cpp
+++ b/src/gui/services/tts_service.cpp
@@ -1,7 +1,1 @@
 #include "tts_service.h"
-
-namespace bookhub::gui {
-
-TTSService::TTSService(QObject *parent) : QObject(parent) {}
-
-} // namespace bookhub::gui

--- a/src/gui/services/tts_service.cpp
+++ b/src/gui/services/tts_service.cpp
@@ -1,1 +1,7 @@
 #include "tts_service.h"
+
+namespace bookhub::gui {
+
+TTSService::~TTSService() = default;
+
+} // namespace bookhub::gui

--- a/src/gui/services/tts_service.cpp
+++ b/src/gui/services/tts_service.cpp
@@ -1,0 +1,7 @@
+#include "tts_service.h"
+
+namespace bookhub::gui {
+
+TTSService::TTSService(QObject *parent) : QObject(parent) {}
+
+} // namespace bookhub::gui

--- a/src/gui/services/tts_service.h
+++ b/src/gui/services/tts_service.h
@@ -18,7 +18,7 @@ namespace bookhub::gui {
 class TTSService : public QObject {
     Q_OBJECT
 public:
-    explicit TTSService(QObject *parent = nullptr);
+    explicit TTSService(QObject *parent = nullptr) : QObject(parent) {}
     virtual ~TTSService() = default;
 
     // Generate preview audio snippet for a voice (non-blocking)

--- a/src/gui/services/tts_service.h
+++ b/src/gui/services/tts_service.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "tts_types.h"
 #include <QObject>
+#include <QList>
 #include <QString>
 
 namespace bookhub::gui {
@@ -37,5 +39,21 @@ signals:
     void generationProgress(int percent);
     void generationCompleted(bool success, const QString &outputPath);
 };
+
+// ---------------------------------------------------------------------------
+// Internal free functions for voice and audiobook-status queries.
+// Used by QueryWorker on the query thread and TestQueryWorker in tests.
+// ---------------------------------------------------------------------------
+namespace internal {
+    QList<VoiceEntry> listVoices(const QString &connectionName);
+    // type must be 'preset' or 'custom'; engine must be 'sherpa_onnx' or 'pocket_tts'.
+    bool insertVoice(const QString &name, const QString &type, const QString &engine,
+                     int *outNewId, const QString &connectionName);
+    bool updateVoice(int voiceId, const QString &engine, const QString &connectionName);
+    bool deleteVoice(int voiceId, const QString &connectionName);
+    bool queryAudiobookStatus(const QString &bookId, bool &outIsReady,
+                               const QString &connectionName);
+    bool setAudiobookReady(const QString &bookId, const QString &connectionName);
+} // namespace internal
 
 } // namespace bookhub::gui

--- a/src/gui/services/tts_service.h
+++ b/src/gui/services/tts_service.h
@@ -19,7 +19,8 @@ class TTSService : public QObject {
     Q_OBJECT
 public:
     explicit TTSService(QObject *parent = nullptr) : QObject(parent) {}
-    virtual ~TTSService() = default;
+    // Defined out-of-line in tts_service.cpp so the vtable has a single anchor.
+    ~TTSService() override;
 
     // Generate preview audio snippet for a voice (non-blocking)
     // Emits previewGenerated(voiceId, audioData) on completion

--- a/src/gui/services/tts_service.h
+++ b/src/gui/services/tts_service.h
@@ -40,20 +40,4 @@ signals:
     void generationCompleted(bool success, const QString &outputPath);
 };
 
-// ---------------------------------------------------------------------------
-// Internal free functions for voice and audiobook-status queries.
-// Used by QueryWorker on the query thread and TestQueryWorker in tests.
-// ---------------------------------------------------------------------------
-namespace internal {
-    QList<VoiceEntry> listVoices(const QString &connectionName);
-    // type must be 'preset' or 'custom'; engine must be 'sherpa_onnx' or 'pocket_tts'.
-    bool insertVoice(const QString &name, const QString &type, const QString &engine,
-                     int *outNewId, const QString &connectionName);
-    bool updateVoice(int voiceId, const QString &engine, const QString &connectionName);
-    bool deleteVoice(int voiceId, const QString &connectionName);
-    bool queryAudiobookStatus(const QString &bookId, bool &outIsReady,
-                               const QString &connectionName);
-    bool setAudiobookReady(const QString &bookId, const QString &connectionName);
-} // namespace internal
-
 } // namespace bookhub::gui

--- a/src/gui/services/tts_service.h
+++ b/src/gui/services/tts_service.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+namespace bookhub::gui {
+
+// ---------------------------------------------------------------------------
+// TTSService — abstract interface for text-to-speech synthesis.
+//
+// Concrete implementations handle voice synthesis, audio generation, and
+// file output. MVP version is a no-op stub; Phase 3+ will integrate with
+// Sherpa-ONNX or PocketTTS.cpp for real TTS.
+// ---------------------------------------------------------------------------
+
+class TTSService : public QObject {
+    Q_OBJECT
+public:
+    explicit TTSService(QObject *parent = nullptr);
+    virtual ~TTSService() = default;
+
+    // Generate preview audio snippet for a voice (non-blocking)
+    // Emits previewGenerated(voiceId, audioData) on completion
+    virtual void generatePreview(int voiceId, const QString &voiceName, const QString &text) = 0;
+
+    // Generate full audiobook audio from text and save to outputPath (non-blocking)
+    // Emits generationProgress(percent) during generation
+    // Emits generationCompleted(success, outputPath) on completion
+    virtual void generateAudiobook(int voiceId, const QString &voiceName, const QString &text,
+                                   const QString &outputPath) = 0;
+
+signals:
+    // Preview generation completed with audio bytes
+    void previewGenerated(int voiceId, const QByteArray &audioData);
+
+    // Audiobook generation progress and completion
+    void generationProgress(int percent);
+    void generationCompleted(bool success, const QString &outputPath);
+};
+
+} // namespace bookhub::gui

--- a/src/gui/services/tts_types.h
+++ b/src/gui/services/tts_types.h
@@ -5,10 +5,12 @@
 
 namespace bookhub::gui {
 
+// Lightweight DTO used by the UI layer. engine/path fields stay in the DB
+// and are fetched by TTSService when audio generation starts (Task 13).
 struct VoiceEntry {
     int id;
     QString name;
-    bool isPreset;
+    bool isPreset; // derived from voices.type == 'preset'
 };
 
 // ---------------------------------------------------------------------------
@@ -17,9 +19,10 @@ struct VoiceEntry {
 // ---------------------------------------------------------------------------
 namespace internal {
     QList<VoiceEntry> listVoices(const QString &connectionName);
-    bool insertVoice(const QString &voiceName, const QString &voiceType, bool isPreset,
+    // type must be 'preset' or 'custom'; engine must be 'sherpa_onnx' or 'pocket_tts'.
+    bool insertVoice(const QString &name, const QString &type, const QString &engine,
                      int *outNewId, const QString &connectionName);
-    bool updateVoice(int voiceId, const QString &voiceType, const QString &connectionName);
+    bool updateVoice(int voiceId, const QString &engine, const QString &connectionName);
     bool deleteVoice(int voiceId, const QString &connectionName);
     bool queryAudiobookStatus(const QString &bookId, bool &outIsReady,
                                const QString &connectionName);

--- a/src/gui/services/tts_types.h
+++ b/src/gui/services/tts_types.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <QString>
+#include <QList>
+
+namespace bookhub::gui {
+
+struct VoiceEntry {
+    int id;
+    QString name;
+    bool isPreset;
+};
+
+// ---------------------------------------------------------------------------
+// Internal free functions for voice and audiobook-status queries.
+// Used by QueryWorker on the query thread and TestQueryWorker in tests.
+// ---------------------------------------------------------------------------
+namespace internal {
+    QList<VoiceEntry> listVoices(const QString &connectionName);
+    bool insertVoice(const QString &voiceName, const QString &voiceType, bool isPreset,
+                     int *outNewId, const QString &connectionName);
+    bool updateVoice(int voiceId, const QString &voiceType, const QString &connectionName);
+    bool deleteVoice(int voiceId, const QString &connectionName);
+    bool queryAudiobookStatus(const QString &bookId, bool &outIsReady,
+                               const QString &connectionName);
+    bool setAudiobookReady(const QString &bookId, const QString &connectionName);
+} // namespace internal
+
+} // namespace bookhub::gui

--- a/src/gui/services/tts_types.h
+++ b/src/gui/services/tts_types.h
@@ -8,25 +8,9 @@ namespace bookhub::gui {
 // Lightweight DTO used by the UI layer. engine/path fields stay in the DB
 // and are fetched by TTSService when audio generation starts (Task 13).
 struct VoiceEntry {
-    int id;
+    int id{-1};
     QString name;
     bool isPreset; // derived from voices.type == 'preset'
 };
-
-// ---------------------------------------------------------------------------
-// Internal free functions for voice and audiobook-status queries.
-// Used by QueryWorker on the query thread and TestQueryWorker in tests.
-// ---------------------------------------------------------------------------
-namespace internal {
-    QList<VoiceEntry> listVoices(const QString &connectionName);
-    // type must be 'preset' or 'custom'; engine must be 'sherpa_onnx' or 'pocket_tts'.
-    bool insertVoice(const QString &name, const QString &type, const QString &engine,
-                     int *outNewId, const QString &connectionName);
-    bool updateVoice(int voiceId, const QString &engine, const QString &connectionName);
-    bool deleteVoice(int voiceId, const QString &connectionName);
-    bool queryAudiobookStatus(const QString &bookId, bool &outIsReady,
-                               const QString &connectionName);
-    bool setAudiobookReady(const QString &bookId, const QString &connectionName);
-} // namespace internal
 
 } // namespace bookhub::gui

--- a/src/gui/services/tts_types.h
+++ b/src/gui/services/tts_types.h
@@ -10,7 +10,7 @@ namespace bookhub::gui {
 struct VoiceEntry {
     int id{-1};
     QString name;
-    bool isPreset; // derived from voices.type == 'preset'
+    bool isPreset{false}; // derived from voices.type == 'preset'
 };
 
 } // namespace bookhub::gui

--- a/src/gui/widgets/mini_audio_player_widget.cpp
+++ b/src/gui/widgets/mini_audio_player_widget.cpp
@@ -1,0 +1,114 @@
+#include "mini_audio_player_widget.h"
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QStyle>
+
+namespace bookhub::gui {
+
+MiniAudioPlayerWidget::MiniAudioPlayerWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    buildUi();
+}
+
+void MiniAudioPlayerWidget::buildUi()
+{
+    m_playPauseBtn = new QPushButton(this);
+    m_playPauseBtn->setText("▶");
+    m_playPauseBtn->setMaximumWidth(40);
+    connect(m_playPauseBtn, &QPushButton::clicked, this, &MiniAudioPlayerWidget::onPlayPauseClicked);
+
+    m_scrubber = new QSlider(Qt::Horizontal, this);
+    m_scrubber->setRange(0, 0);
+    m_scrubber->setFocusPolicy(Qt::StrongFocus);
+    connect(m_scrubber, &QSlider::sliderMoved, this, &MiniAudioPlayerWidget::onSliderMoved);
+    connect(m_scrubber, &QSlider::sliderPressed, this, &MiniAudioPlayerWidget::onSliderPressed);
+    connect(m_scrubber, &QSlider::sliderReleased, this, &MiniAudioPlayerWidget::onSliderReleased);
+
+    m_timeLabel = new QLabel("0:00 / 0:00", this);
+    m_timeLabel->setMaximumWidth(80);
+    m_timeLabel->setStyleSheet("QLabel { color: #6B7280; font-size: 11px; }");
+
+    QHBoxLayout *layout = new QHBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->addWidget(m_playPauseBtn);
+    layout->addWidget(m_scrubber);
+    layout->addWidget(m_timeLabel);
+
+    setMaximumHeight(32);
+}
+
+void MiniAudioPlayerWidget::setDuration(qint64 durationMs)
+{
+    m_duration = durationMs;
+    if (durationMs > 0) {
+        m_scrubber->setRange(0, static_cast<int>(durationMs / 100));
+    }
+    updateTimeLabel();
+}
+
+void MiniAudioPlayerWidget::setCurrentTime(qint64 currentTimeMs)
+{
+    m_currentTime = currentTimeMs;
+    if (!m_sliderPressed && m_duration > 0) {
+        m_scrubber->blockSignals(true);
+        m_scrubber->setValue(static_cast<int>(currentTimeMs / 100));
+        m_scrubber->blockSignals(false);
+    }
+    updateTimeLabel();
+}
+
+bool MiniAudioPlayerWidget::isPlaying() const
+{
+    return m_isPlaying;
+}
+
+void MiniAudioPlayerWidget::onPlayPauseClicked()
+{
+    m_isPlaying = !m_isPlaying;
+    m_playPauseBtn->setText(m_isPlaying ? "⏸" : "▶");
+    if (m_isPlaying) {
+        emit playClicked();
+    } else {
+        emit pauseClicked();
+    }
+}
+
+void MiniAudioPlayerWidget::onSliderMoved(int position)
+{
+    m_currentTime = static_cast<qint64>(position) * 100;
+    updateTimeLabel();
+}
+
+void MiniAudioPlayerWidget::onSliderPressed()
+{
+    m_sliderPressed = true;
+}
+
+void MiniAudioPlayerWidget::onSliderReleased()
+{
+    m_sliderPressed = false;
+    m_currentTime = static_cast<qint64>(m_scrubber->value()) * 100;
+    emit seekRequested(m_currentTime);
+}
+
+void MiniAudioPlayerWidget::updateTimeLabel()
+{
+    int currentSecs = static_cast<int>(m_currentTime / 1000);
+    int totalSecs = static_cast<int>(m_duration / 1000);
+
+    int curMins = currentSecs / 60;
+    int curSecs = currentSecs % 60;
+    int totMins = totalSecs / 60;
+    int totSecs = totalSecs % 60;
+
+    QString timeStr = QString("%1:%2 / %3:%4")
+        .arg(curMins)
+        .arg(curSecs, 2, 10, QLatin1Char('0'))
+        .arg(totMins)
+        .arg(totSecs, 2, 10, QLatin1Char('0'));
+
+    m_timeLabel->setText(timeStr);
+}
+
+} // namespace bookhub::gui

--- a/src/gui/widgets/mini_audio_player_widget.h
+++ b/src/gui/widgets/mini_audio_player_widget.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <QWidget>
+#include <QSlider>
+#include <QPushButton>
+#include <QLabel>
+
+namespace bookhub::gui {
+
+class MiniAudioPlayerWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit MiniAudioPlayerWidget(QWidget *parent = nullptr);
+
+    void setDuration(qint64 durationMs);
+    void setCurrentTime(qint64 currentTimeMs);
+    bool isPlaying() const;
+
+signals:
+    void playClicked();
+    void pauseClicked();
+    void seekRequested(qint64 positionMs);
+
+private slots:
+    void onPlayPauseClicked();
+    void onSliderMoved(int position);
+    void onSliderPressed();
+    void onSliderReleased();
+
+private:
+    void buildUi();
+    void updateTimeLabel();
+
+    bool m_isPlaying{false};
+    qint64 m_duration{0};
+    qint64 m_currentTime{0};
+    bool m_sliderPressed{false};
+
+    QPushButton *m_playPauseBtn{};
+    QSlider *m_scrubber{};
+    QLabel *m_timeLabel{};
+};
+
+} // namespace bookhub::gui

--- a/src/gui/widgets/voice_selector_widget.cpp
+++ b/src/gui/widgets/voice_selector_widget.cpp
@@ -24,11 +24,12 @@ void VoiceSelectorWidget::buildUi()
     m_presetList = new QListWidget(this);
     m_presetList->setSelectionMode(QAbstractItemView::SingleSelection);
     m_presetList->setMaximumHeight(120);
-    connect(m_presetList, &QListWidget::itemClicked, this,
-            [this](QListWidgetItem *item) {
+    connect(m_presetList, &QListWidget::currentItemChanged, this,
+            [this](QListWidgetItem *current, QListWidgetItem *) {
+                if (!current) return;
                 m_customList->clearSelection();
-                m_selectedVoiceId = item->data(Qt::UserRole).toInt();
-                emit voiceSelected(m_selectedVoiceId, item->text());
+                m_selectedVoiceId = current->data(Qt::UserRole).toInt();
+                emit voiceSelected(m_selectedVoiceId, current->text());
             });
     mainLayout->addWidget(m_presetList);
 
@@ -39,11 +40,12 @@ void VoiceSelectorWidget::buildUi()
     m_customList = new QListWidget(this);
     m_customList->setSelectionMode(QAbstractItemView::SingleSelection);
     m_customList->setMaximumHeight(100);
-    connect(m_customList, &QListWidget::itemClicked, this,
-            [this](QListWidgetItem *item) {
+    connect(m_customList, &QListWidget::currentItemChanged, this,
+            [this](QListWidgetItem *current, QListWidgetItem *) {
+                if (!current) return;
                 m_presetList->clearSelection();
-                m_selectedVoiceId = item->data(Qt::UserRole).toInt();
-                emit voiceSelected(m_selectedVoiceId, item->text());
+                m_selectedVoiceId = current->data(Qt::UserRole).toInt();
+                emit voiceSelected(m_selectedVoiceId, current->text());
             });
     mainLayout->addWidget(m_customList);
 
@@ -58,6 +60,7 @@ void VoiceSelectorWidget::buildUi()
 
 void VoiceSelectorWidget::setVoices(const QList<VoiceEntry> &voices)
 {
+    m_selectedVoiceId = -1;
     m_voices = voices;
     populateVoiceList();
 }

--- a/src/gui/widgets/voice_selector_widget.cpp
+++ b/src/gui/widgets/voice_selector_widget.cpp
@@ -1,0 +1,132 @@
+#include "voice_selector_widget.h"
+#include <QListWidget>
+#include <QListWidgetItem>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+
+namespace bookhub::gui {
+
+VoiceSelectorWidget::VoiceSelectorWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    buildUi();
+}
+
+void VoiceSelectorWidget::buildUi()
+{
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+
+    // Preset voices section
+    QLabel *presetLabel = new QLabel("Preset voices", this);
+    presetLabel->setStyleSheet("QLabel { font-weight: bold; font-size: 12px; margin-top: 8px; }");
+    mainLayout->addWidget(presetLabel);
+
+    m_presetList = new QListWidget(this);
+    m_presetList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_presetList->setMaximumHeight(120);
+    connect(m_presetList, &QListWidget::itemClicked, this, &VoiceSelectorWidget::onVoiceItemClicked);
+    mainLayout->addWidget(m_presetList);
+
+    // Custom voices section
+    QLabel *customLabel = new QLabel("Custom voices", this);
+    customLabel->setStyleSheet("QLabel { font-weight: bold; font-size: 12px; margin-top: 12px; }");
+    mainLayout->addWidget(customLabel);
+
+    m_customList = new QListWidget(this);
+    m_customList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_customList->setMaximumHeight(100);
+    connect(m_customList, &QListWidget::itemClicked, this, &VoiceSelectorWidget::onVoiceItemClicked);
+    mainLayout->addWidget(m_customList);
+
+    m_uploadBtn = new QPushButton("+ Upload new voice sample", this);
+    m_uploadBtn->setMaximumWidth(200);
+    connect(m_uploadBtn, &QPushButton::clicked, this, &VoiceSelectorWidget::onUploadClicked);
+    mainLayout->addWidget(m_uploadBtn);
+
+    mainLayout->addStretch();
+    setMaximumHeight(400);
+}
+
+void VoiceSelectorWidget::setVoices(const QList<VoiceEntry> &voices)
+{
+    m_voices = voices;
+    populateVoiceList();
+}
+
+QString VoiceSelectorWidget::selectedVoiceName() const
+{
+    for (const auto &voice : m_voices) {
+        if (voice.id == m_selectedVoiceId) {
+            return voice.name;
+        }
+    }
+    return QString();
+}
+
+int VoiceSelectorWidget::selectedVoiceId() const
+{
+    return m_selectedVoiceId;
+}
+
+void VoiceSelectorWidget::onVoiceItemClicked()
+{
+    QListWidget *senderList = qobject_cast<QListWidget *>(sender());
+    if (!senderList)
+        senderList = m_presetList;
+
+    // Clear selection on the other list
+    if (senderList == m_presetList) {
+        m_customList->clearSelection();
+    } else {
+        m_presetList->clearSelection();
+    }
+
+    QListWidgetItem *item = senderList->currentItem();
+    if (!item)
+        return;
+
+    m_selectedVoiceId = item->data(Qt::UserRole).toInt();
+    QString voiceName = item->text().split(" [")[0];
+    emit voiceSelected(m_selectedVoiceId, voiceName);
+}
+
+void VoiceSelectorWidget::onPreviewButtonClicked()
+{
+    // This would be called by a button in the item widget
+    // For now, placeholder
+}
+
+void VoiceSelectorWidget::onUploadClicked()
+{
+    emit uploadNewVoiceRequested();
+}
+
+void VoiceSelectorWidget::populateVoiceList()
+{
+    m_presetList->clear();
+    m_customList->clear();
+
+    for (const auto &voice : m_voices) {
+        QString displayText = voice.name + " [▶ Preview]";
+        QListWidgetItem *item = new QListWidgetItem(displayText);
+        item->setData(Qt::UserRole, voice.id);
+
+        if (voice.isPreset) {
+            m_presetList->addItem(item);
+        } else {
+            m_customList->addItem(item);
+        }
+    }
+}
+
+void VoiceSelectorWidget::updatePresetSection()
+{
+}
+
+void VoiceSelectorWidget::updateCustomSection()
+{
+}
+
+} // namespace bookhub::gui

--- a/src/gui/widgets/voice_selector_widget.cpp
+++ b/src/gui/widgets/voice_selector_widget.cpp
@@ -70,7 +70,7 @@ void VoiceSelectorWidget::onVoiceItemClicked()
 {
     QListWidget *senderList = qobject_cast<QListWidget *>(sender());
     if (!senderList)
-        senderList = m_presetList;
+        return;
 
     if (senderList == m_presetList)
         m_customList->clearSelection();

--- a/src/gui/widgets/voice_selector_widget.cpp
+++ b/src/gui/widgets/voice_selector_widget.cpp
@@ -24,7 +24,12 @@ void VoiceSelectorWidget::buildUi()
     m_presetList = new QListWidget(this);
     m_presetList->setSelectionMode(QAbstractItemView::SingleSelection);
     m_presetList->setMaximumHeight(120);
-    connect(m_presetList, &QListWidget::itemClicked, this, &VoiceSelectorWidget::onVoiceItemClicked);
+    connect(m_presetList, &QListWidget::itemClicked, this,
+            [this](QListWidgetItem *item) {
+                m_customList->clearSelection();
+                m_selectedVoiceId = item->data(Qt::UserRole).toInt();
+                emit voiceSelected(m_selectedVoiceId, item->text());
+            });
     mainLayout->addWidget(m_presetList);
 
     QLabel *customLabel = new QLabel("Custom voices", this);
@@ -34,7 +39,12 @@ void VoiceSelectorWidget::buildUi()
     m_customList = new QListWidget(this);
     m_customList->setSelectionMode(QAbstractItemView::SingleSelection);
     m_customList->setMaximumHeight(100);
-    connect(m_customList, &QListWidget::itemClicked, this, &VoiceSelectorWidget::onVoiceItemClicked);
+    connect(m_customList, &QListWidget::itemClicked, this,
+            [this](QListWidgetItem *item) {
+                m_presetList->clearSelection();
+                m_selectedVoiceId = item->data(Qt::UserRole).toInt();
+                emit voiceSelected(m_selectedVoiceId, item->text());
+            });
     mainLayout->addWidget(m_customList);
 
     m_uploadBtn = new QPushButton("+ Upload new voice sample", this);
@@ -64,25 +74,6 @@ QString VoiceSelectorWidget::selectedVoiceName() const
 int VoiceSelectorWidget::selectedVoiceId() const
 {
     return m_selectedVoiceId;
-}
-
-void VoiceSelectorWidget::onVoiceItemClicked()
-{
-    QListWidget *senderList = qobject_cast<QListWidget *>(sender());
-    if (!senderList)
-        return;
-
-    if (senderList == m_presetList)
-        m_customList->clearSelection();
-    else
-        m_presetList->clearSelection();
-
-    QListWidgetItem *item = senderList->currentItem();
-    if (!item)
-        return;
-
-    m_selectedVoiceId = item->data(Qt::UserRole).toInt();
-    emit voiceSelected(m_selectedVoiceId, item->text());
 }
 
 void VoiceSelectorWidget::onUploadClicked()

--- a/src/gui/widgets/voice_selector_widget.cpp
+++ b/src/gui/widgets/voice_selector_widget.cpp
@@ -3,7 +3,6 @@
 #include <QListWidgetItem>
 #include <QPushButton>
 #include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QLabel>
 
 namespace bookhub::gui {
@@ -18,7 +17,6 @@ void VoiceSelectorWidget::buildUi()
 {
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
-    // Preset voices section
     QLabel *presetLabel = new QLabel("Preset voices", this);
     presetLabel->setStyleSheet("QLabel { font-weight: bold; font-size: 12px; margin-top: 8px; }");
     mainLayout->addWidget(presetLabel);
@@ -29,7 +27,6 @@ void VoiceSelectorWidget::buildUi()
     connect(m_presetList, &QListWidget::itemClicked, this, &VoiceSelectorWidget::onVoiceItemClicked);
     mainLayout->addWidget(m_presetList);
 
-    // Custom voices section
     QLabel *customLabel = new QLabel("Custom voices", this);
     customLabel->setStyleSheet("QLabel { font-weight: bold; font-size: 12px; margin-top: 12px; }");
     mainLayout->addWidget(customLabel);
@@ -58,9 +55,8 @@ void VoiceSelectorWidget::setVoices(const QList<VoiceEntry> &voices)
 QString VoiceSelectorWidget::selectedVoiceName() const
 {
     for (const auto &voice : m_voices) {
-        if (voice.id == m_selectedVoiceId) {
+        if (voice.id == m_selectedVoiceId)
             return voice.name;
-        }
     }
     return QString();
 }
@@ -76,26 +72,17 @@ void VoiceSelectorWidget::onVoiceItemClicked()
     if (!senderList)
         senderList = m_presetList;
 
-    // Clear selection on the other list
-    if (senderList == m_presetList) {
+    if (senderList == m_presetList)
         m_customList->clearSelection();
-    } else {
+    else
         m_presetList->clearSelection();
-    }
 
     QListWidgetItem *item = senderList->currentItem();
     if (!item)
         return;
 
     m_selectedVoiceId = item->data(Qt::UserRole).toInt();
-    QString voiceName = item->text().split(" [")[0];
-    emit voiceSelected(m_selectedVoiceId, voiceName);
-}
-
-void VoiceSelectorWidget::onPreviewButtonClicked()
-{
-    // This would be called by a button in the item widget
-    // For now, placeholder
+    emit voiceSelected(m_selectedVoiceId, item->text());
 }
 
 void VoiceSelectorWidget::onUploadClicked()
@@ -109,24 +96,14 @@ void VoiceSelectorWidget::populateVoiceList()
     m_customList->clear();
 
     for (const auto &voice : m_voices) {
-        QString displayText = voice.name + " [▶ Preview]";
-        QListWidgetItem *item = new QListWidgetItem(displayText);
+        QListWidgetItem *item = new QListWidgetItem(voice.name);
         item->setData(Qt::UserRole, voice.id);
 
-        if (voice.isPreset) {
+        if (voice.isPreset)
             m_presetList->addItem(item);
-        } else {
+        else
             m_customList->addItem(item);
-        }
     }
-}
-
-void VoiceSelectorWidget::updatePresetSection()
-{
-}
-
-void VoiceSelectorWidget::updateCustomSection()
-{
 }
 
 } // namespace bookhub::gui

--- a/src/gui/widgets/voice_selector_widget.h
+++ b/src/gui/widgets/voice_selector_widget.h
@@ -1,19 +1,12 @@
 #pragma once
 
+#include "../services/tts_types.h"
 #include <QWidget>
-#include <QString>
-#include <QList>
 
 class QListWidget;
 class QPushButton;
 
 namespace bookhub::gui {
-
-struct VoiceEntry {
-    int id;
-    QString name;
-    bool isPreset;
-};
 
 class VoiceSelectorWidget : public QWidget {
     Q_OBJECT
@@ -27,19 +20,15 @@ public:
 
 signals:
     void voiceSelected(int voiceId, const QString &voiceName);
-    void voicePreviewRequested(int voiceId, const QString &voiceName);
     void uploadNewVoiceRequested();
 
 private slots:
     void onVoiceItemClicked();
-    void onPreviewButtonClicked();
     void onUploadClicked();
 
 private:
     void buildUi();
     void populateVoiceList();
-    void updatePresetSection();
-    void updateCustomSection();
 
     QList<VoiceEntry> m_voices;
     int m_selectedVoiceId{-1};

--- a/src/gui/widgets/voice_selector_widget.h
+++ b/src/gui/widgets/voice_selector_widget.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QWidget>
+#include <QString>
+#include <QList>
+
+class QListWidget;
+class QPushButton;
+
+namespace bookhub::gui {
+
+struct VoiceEntry {
+    int id;
+    QString name;
+    bool isPreset;
+};
+
+class VoiceSelectorWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit VoiceSelectorWidget(QWidget *parent = nullptr);
+
+    void setVoices(const QList<VoiceEntry> &voices);
+    QString selectedVoiceName() const;
+    int selectedVoiceId() const;
+
+signals:
+    void voiceSelected(int voiceId, const QString &voiceName);
+    void voicePreviewRequested(int voiceId, const QString &voiceName);
+    void uploadNewVoiceRequested();
+
+private slots:
+    void onVoiceItemClicked();
+    void onPreviewButtonClicked();
+    void onUploadClicked();
+
+private:
+    void buildUi();
+    void populateVoiceList();
+    void updatePresetSection();
+    void updateCustomSection();
+
+    QList<VoiceEntry> m_voices;
+    int m_selectedVoiceId{-1};
+
+    QListWidget *m_presetList{};
+    QListWidget *m_customList{};
+    QPushButton *m_uploadBtn{};
+};
+
+} // namespace bookhub::gui

--- a/src/gui/widgets/voice_selector_widget.h
+++ b/src/gui/widgets/voice_selector_widget.h
@@ -23,7 +23,6 @@ signals:
     void uploadNewVoiceRequested();
 
 private slots:
-    void onVoiceItemClicked();
     void onUploadClicked();
 
 private:

--- a/src/shared/database.cpp
+++ b/src/shared/database.cpp
@@ -220,7 +220,10 @@ bool verifySchemaVersion(const QString &connectionName)
             "INSERT OR IGNORE INTO library_items_new SELECT * FROM library_items",
             "DROP TABLE library_items",
             "ALTER TABLE library_items_new RENAME TO library_items",
-            QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion),
+            // Stamp the version this migration produces, not kSchemaVersion —
+            // otherwise bumping the schema later (e.g. v3, v4, …) would cause a
+            // v1 DB to skip every intermediate migration step.
+            QStringLiteral("PRAGMA user_version = 2"),
             "COMMIT",
             "PRAGMA foreign_keys = ON"
         };
@@ -236,7 +239,9 @@ bool verifySchemaVersion(const QString &connectionName)
             }
         }
         qDebug() << "Migration to schema version 2 complete.";
-        return true;
+        // Chain into the next migration so a v1 DB lands at the current
+        // schema version in a single startup.
+        return verifySchemaVersion(connectionName);
     }
 
     // Migration: version 2 → 3
@@ -281,7 +286,9 @@ bool verifySchemaVersion(const QString &connectionName)
             "INSERT INTO library_items_new SELECT * FROM library_items",
             "DROP TABLE library_items",
             "ALTER TABLE library_items_new RENAME TO library_items",
-            QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion),
+            // Hard-code the version this migration produces so a future v3→v4
+            // migration is not silently skipped by a stale kSchemaVersion stamp.
+            QStringLiteral("PRAGMA user_version = 3"),
             "COMMIT",
             "PRAGMA foreign_keys = ON"
         };
@@ -297,7 +304,9 @@ bool verifySchemaVersion(const QString &connectionName)
             }
         }
         qDebug() << "Migration to schema version 3 complete.";
-        return true;
+        // Chain into any future migration so a single startup advances the DB
+        // all the way to kSchemaVersion. Today this just returns true.
+        return verifySchemaVersion(connectionName);
     }
 
     qCritical("Database schema version mismatch: expected %d, found %d. "

--- a/src/shared/database.cpp
+++ b/src/shared/database.cpp
@@ -110,6 +110,13 @@ bool createSchema(const QString &connectionName)
             status TEXT,
             FOREIGN KEY (book_id) REFERENCES books(book_id) ON DELETE CASCADE ON UPDATE CASCADE,
             FOREIGN KEY (edition_id) REFERENCES editions(id)
+        ))",
+        R"(CREATE TABLE IF NOT EXISTS voices (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            voice_name TEXT NOT NULL UNIQUE,
+            voice_type TEXT NOT NULL,
+            is_preset INTEGER DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         ))"
     };
 
@@ -216,6 +223,36 @@ bool verifySchemaVersion(const QString &connectionName)
         return true;
     }
 
+    // Migration: version 2 → 3
+    // Adds voices table for preset and custom voice storage
+    if (version == 2) {
+        qDebug() << "Migrating database schema from version 2 to 3...";
+        QStringList migration = {
+            "BEGIN",
+            R"(CREATE TABLE IF NOT EXISTS voices (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                voice_name TEXT NOT NULL UNIQUE,
+                voice_type TEXT NOT NULL,
+                is_preset INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            ))",
+            QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion),
+            "COMMIT"
+        };
+
+        QSqlQuery mq(db);
+        for (const QString &sql : migration) {
+            if (!mq.exec(sql)) {
+                qCritical() << "Migration v2→v3 failed at:" << sql
+                            << "\nError:" << mq.lastError().text();
+                mq.exec("ROLLBACK");
+                return false;
+            }
+        }
+        qDebug() << "Migration to schema version 3 complete.";
+        return true;
+    }
+
     qCritical("Database schema version mismatch: expected %d, found %d. "
               "Run tools/migrate_db.py to upgrade the database.",
               kSchemaVersion, version);
@@ -270,6 +307,11 @@ bool insertSampleData(const QString &connectionName)
         R"(INSERT OR IGNORE INTO library_items (book_id, edition_id, status) VALUES
             ('lccn:n78095332', 1, 'saved'),
             ('lccn:n79025140', 3, 'downloaded')
+        )",
+        R"(INSERT OR IGNORE INTO voices (voice_name, voice_type, is_preset) VALUES
+            ('Classic Storyteller', 'preset', 1),
+            ('Warm Listener', 'preset', 1),
+            ('Crisp Narrator', 'preset', 1)
         )"
     };
 

--- a/src/shared/database.cpp
+++ b/src/shared/database.cpp
@@ -112,11 +112,14 @@ bool createSchema(const QString &connectionName)
             FOREIGN KEY (edition_id) REFERENCES editions(id)
         ))",
         R"(CREATE TABLE IF NOT EXISTS voices (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            voice_name TEXT NOT NULL UNIQUE,
-            voice_type TEXT NOT NULL,
-            is_preset INTEGER DEFAULT 0,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name                 TEXT NOT NULL,
+            type                 TEXT NOT NULL CHECK(type IN ('preset', 'custom')),
+            engine               TEXT NOT NULL CHECK(engine IN ('sherpa_onnx', 'pocket_tts')),
+            model_path           TEXT,
+            config_path          TEXT,
+            reference_audio_path TEXT,
+            created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         ))"
     };
 
@@ -230,11 +233,14 @@ bool verifySchemaVersion(const QString &connectionName)
         QStringList migration = {
             "BEGIN",
             R"(CREATE TABLE IF NOT EXISTS voices (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                voice_name TEXT NOT NULL UNIQUE,
-                voice_type TEXT NOT NULL,
-                is_preset INTEGER DEFAULT 0,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+                name                 TEXT NOT NULL,
+                type                 TEXT NOT NULL CHECK(type IN ('preset', 'custom')),
+                engine               TEXT NOT NULL CHECK(engine IN ('sherpa_onnx', 'pocket_tts')),
+                model_path           TEXT,
+                config_path          TEXT,
+                reference_audio_path TEXT,
+                created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             ))",
             QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion),
             "COMMIT"
@@ -308,10 +314,10 @@ bool insertSampleData(const QString &connectionName)
             ('lccn:n78095332', 1, 'saved'),
             ('lccn:n79025140', 3, 'downloaded')
         )",
-        R"(INSERT OR IGNORE INTO voices (voice_name, voice_type, is_preset) VALUES
-            ('Classic Storyteller', 'preset', 1),
-            ('Warm Listener', 'preset', 1),
-            ('Crisp Narrator', 'preset', 1)
+        R"(INSERT OR IGNORE INTO voices (name, type, engine) VALUES
+            ('Classic Storyteller', 'preset', 'sherpa_onnx'),
+            ('Warm Listener',       'preset', 'sherpa_onnx'),
+            ('Crisp Narrator',      'preset', 'sherpa_onnx')
         )"
     };
 

--- a/src/shared/database.cpp
+++ b/src/shared/database.cpp
@@ -113,7 +113,7 @@ bool createSchema(const QString &connectionName)
         ))",
         R"(CREATE TABLE IF NOT EXISTS voices (
             id                   INTEGER PRIMARY KEY AUTOINCREMENT,
-            name                 TEXT NOT NULL,
+            name                 TEXT NOT NULL UNIQUE,
             type                 TEXT NOT NULL CHECK(type IN ('preset', 'custom')),
             engine               TEXT NOT NULL CHECK(engine IN ('sherpa_onnx', 'pocket_tts')),
             model_path           TEXT,
@@ -133,7 +133,7 @@ bool createSchema(const QString &connectionName)
     // Seed the three preset voices. These are product baseline data (not dev
     // sample data), so they live here rather than in insertSampleData so
     // production Release builds — which skip insertSampleData — still get them.
-    // Idempotent via INSERT OR IGNORE.
+    // UNIQUE(name) on the voices table makes this genuinely idempotent.
     if (!query.exec(QStringLiteral(
             "INSERT OR IGNORE INTO voices (name, type, engine) VALUES "
             "('Classic Storyteller', 'preset', 'sherpa_onnx'),"
@@ -241,9 +241,7 @@ bool verifySchemaVersion(const QString &connectionName)
 
     // Migration: version 2 → 3
     // Adds voices table for preset and custom voice storage, and a CHECK
-    // constraint on library_items.status so typos cannot silently land bad
-    // data. Preset rows are seeded by createSchema() (which runs immediately
-    // after this returns).
+    // constraint on library_items.status so typos cannot silently land bad data.
     if (version == 2) {
         qDebug() << "Migrating database schema from version 2 to 3...";
         QStringList migration = {
@@ -253,7 +251,7 @@ bool verifySchemaVersion(const QString &connectionName)
             "BEGIN",
             R"(CREATE TABLE IF NOT EXISTS voices (
                 id                   INTEGER PRIMARY KEY AUTOINCREMENT,
-                name                 TEXT NOT NULL,
+                name                 TEXT NOT NULL UNIQUE,
                 type                 TEXT NOT NULL CHECK(type IN ('preset', 'custom')),
                 engine               TEXT NOT NULL CHECK(engine IN ('sherpa_onnx', 'pocket_tts')),
                 model_path           TEXT,
@@ -261,6 +259,12 @@ bool verifySchemaVersion(const QString &connectionName)
                 reference_audio_path TEXT,
                 created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             ))",
+            // Seed preset voices here so users upgrading from v2 get them
+            // immediately, without waiting for another createSchema() call.
+            QStringLiteral("INSERT OR IGNORE INTO voices (name, type, engine) VALUES "
+                           "('Classic Storyteller', 'preset', 'sherpa_onnx'),"
+                           "('Warm Listener',       'preset', 'sherpa_onnx'),"
+                           "('Crisp Narrator',      'preset', 'sherpa_onnx')"),
             // Recreate library_items with CHECK constraint on status.
             // SQLite does not support ALTER TABLE ADD CONSTRAINT.
             R"(CREATE TABLE library_items_new (
@@ -272,7 +276,9 @@ bool verifySchemaVersion(const QString &connectionName)
                 FOREIGN KEY (book_id) REFERENCES books(book_id) ON DELETE CASCADE ON UPDATE CASCADE,
                 FOREIGN KEY (edition_id) REFERENCES editions(id)
             ))",
-            "INSERT OR IGNORE INTO library_items_new SELECT * FROM library_items",
+            // Fail loudly if any existing status value violates the new constraint
+            // rather than silently discarding rows.
+            "INSERT INTO library_items_new SELECT * FROM library_items",
             "DROP TABLE library_items",
             "ALTER TABLE library_items_new RENAME TO library_items",
             QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion),

--- a/src/shared/database.cpp
+++ b/src/shared/database.cpp
@@ -242,6 +242,11 @@ bool verifySchemaVersion(const QString &connectionName)
                 reference_audio_path TEXT,
                 created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             ))",
+            R"(INSERT OR IGNORE INTO voices (name, type, engine) VALUES
+                ('Classic Storyteller', 'preset', 'sherpa_onnx'),
+                ('Warm Listener',       'preset', 'sherpa_onnx'),
+                ('Crisp Narrator',      'preset', 'sherpa_onnx')
+            )",
             QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion),
             "COMMIT"
         };

--- a/src/shared/database.cpp
+++ b/src/shared/database.cpp
@@ -107,7 +107,7 @@ bool createSchema(const QString &connectionName)
             book_id TEXT NOT NULL UNIQUE,
             edition_id INTEGER,
             added_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            status TEXT,
+            status TEXT CHECK(status IS NULL OR status IN ('saved', 'downloading', 'downloaded', 'converting', 'audiobook_ready', 'error')),
             FOREIGN KEY (book_id) REFERENCES books(book_id) ON DELETE CASCADE ON UPDATE CASCADE,
             FOREIGN KEY (edition_id) REFERENCES editions(id)
         ))",
@@ -128,6 +128,19 @@ bool createSchema(const QString &connectionName)
             qWarning() << "Failed to create table:" << query.lastError().text() << "\nQuery:" << sql;
             return false;
         }
+    }
+
+    // Seed the three preset voices. These are product baseline data (not dev
+    // sample data), so they live here rather than in insertSampleData so
+    // production Release builds — which skip insertSampleData — still get them.
+    // Idempotent via INSERT OR IGNORE.
+    if (!query.exec(QStringLiteral(
+            "INSERT OR IGNORE INTO voices (name, type, engine) VALUES "
+            "('Classic Storyteller', 'preset', 'sherpa_onnx'),"
+            "('Warm Listener',       'preset', 'sherpa_onnx'),"
+            "('Crisp Narrator',      'preset', 'sherpa_onnx')"))) {
+        qWarning() << "Failed to seed preset voices:" << query.lastError().text();
+        return false;
     }
 
     if (!query.exec(QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion))) {
@@ -227,10 +240,16 @@ bool verifySchemaVersion(const QString &connectionName)
     }
 
     // Migration: version 2 → 3
-    // Adds voices table for preset and custom voice storage
+    // Adds voices table for preset and custom voice storage, and a CHECK
+    // constraint on library_items.status so typos cannot silently land bad
+    // data. Preset rows are seeded by createSchema() (which runs immediately
+    // after this returns).
     if (version == 2) {
         qDebug() << "Migrating database schema from version 2 to 3...";
         QStringList migration = {
+            // PRAGMA must run outside a transaction; FK checks are disabled
+            // during the table-recreation dance for library_items.
+            "PRAGMA foreign_keys = OFF",
             "BEGIN",
             R"(CREATE TABLE IF NOT EXISTS voices (
                 id                   INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -242,13 +261,23 @@ bool verifySchemaVersion(const QString &connectionName)
                 reference_audio_path TEXT,
                 created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             ))",
-            R"(INSERT OR IGNORE INTO voices (name, type, engine) VALUES
-                ('Classic Storyteller', 'preset', 'sherpa_onnx'),
-                ('Warm Listener',       'preset', 'sherpa_onnx'),
-                ('Crisp Narrator',      'preset', 'sherpa_onnx')
-            )",
+            // Recreate library_items with CHECK constraint on status.
+            // SQLite does not support ALTER TABLE ADD CONSTRAINT.
+            R"(CREATE TABLE library_items_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                book_id TEXT NOT NULL UNIQUE,
+                edition_id INTEGER,
+                added_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                status TEXT CHECK(status IS NULL OR status IN ('saved', 'downloading', 'downloaded', 'converting', 'audiobook_ready', 'error')),
+                FOREIGN KEY (book_id) REFERENCES books(book_id) ON DELETE CASCADE ON UPDATE CASCADE,
+                FOREIGN KEY (edition_id) REFERENCES editions(id)
+            ))",
+            "INSERT OR IGNORE INTO library_items_new SELECT * FROM library_items",
+            "DROP TABLE library_items",
+            "ALTER TABLE library_items_new RENAME TO library_items",
             QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion),
-            "COMMIT"
+            "COMMIT",
+            "PRAGMA foreign_keys = ON"
         };
 
         QSqlQuery mq(db);
@@ -257,6 +286,7 @@ bool verifySchemaVersion(const QString &connectionName)
                 qCritical() << "Migration v2→v3 failed at:" << sql
                             << "\nError:" << mq.lastError().text();
                 mq.exec("ROLLBACK");
+                mq.exec("PRAGMA foreign_keys = ON");
                 return false;
             }
         }
@@ -318,12 +348,9 @@ bool insertSampleData(const QString &connectionName)
         R"(INSERT OR IGNORE INTO library_items (book_id, edition_id, status) VALUES
             ('lccn:n78095332', 1, 'saved'),
             ('lccn:n79025140', 3, 'downloaded')
-        )",
-        R"(INSERT OR IGNORE INTO voices (name, type, engine) VALUES
-            ('Classic Storyteller', 'preset', 'sherpa_onnx'),
-            ('Warm Listener',       'preset', 'sherpa_onnx'),
-            ('Crisp Narrator',      'preset', 'sherpa_onnx')
         )"
+        // NOTE: preset voices are seeded by createSchema() so they exist in
+        // production builds (which skip insertSampleData under !QT_DEBUG).
     };
 
     for (const QString &sql : inserts) {

--- a/src/shared/database.h
+++ b/src/shared/database.h
@@ -6,7 +6,7 @@
 
 namespace bookhub::db {
 
-inline constexpr int kSchemaVersion = 2;
+inline constexpr int kSchemaVersion = 3;
 
 /// Returns the absolute path to the database file, located next to the executable.
 QString databaseFilePath();

--- a/tests/gui/test_audiobook_flow_dialog.cpp
+++ b/tests/gui/test_audiobook_flow_dialog.cpp
@@ -1,12 +1,12 @@
 #include <QtTest>
 #include <QLabel>
 #include <QListWidget>
+#include <QProgressBar>
 #include <QPushButton>
-#include <QComboBox>
+#include <QSignalSpy>
 
 #include "gui/dialogs/audiobook_flow_dialog.h"
 #include "gui/services/library_service.h"
-#include "gui/widgets/step_indicator_widget.h"
 #include "gui/widgets/voice_selector_widget.h"
 #include "support/test_query_worker.h"
 
@@ -19,35 +19,36 @@ private slots:
     void init();
     void cleanup();
 
-    // Construction and dialog lifecycle
-    void construction_createsDialog();
-    void startForBook_setsBookId();
-    void dialog_initializes_at_step1();
-
-    // Language selection (Step 1)
-    void languageSelection_populatesLanguages();
-    void languageSelection_canSelectLanguage();
-
-    // Format selection (Step 2)
-    void formatSelection_populatesFormats();
-    void formatSelection_selectsFormat();
-
-    // Voice selection (Step 3)
-    void voiceSelection_populatesVoices();
-    void voiceSelection_emitsSignalOnChange();
-    void voiceSelection_supportsPresetAndCustom();
+    // Construction
+    void construction_isModalAtStep0_backHidden();
 
     // Navigation
+    void backNavigation_clampedAtStep0();
     void backNavigation_decrementsStep();
     void nextNavigation_incrementsStep();
-    void nextButton_requiresSelectionsPerStep();
+
+    // Details/formats injection
+    void singleEdition_autoSelectsLanguage();
+    void multipleEditions_requiresLanguageStep();
+    void staleDetailsRequest_isIgnored();
+    void staleFormatsRequest_isIgnored();
+
+    // Format list
+    void populateFormatList_autoSelectsEpub();
+    void populateFormatList_selectsFirstWhenNoEpub();
+
+    // Voice list
+    void voiceSelector_displaysPresetAndCustomSeparately();
+
+    // Generation flow
+    void startGeneration_succeedsWithAllSelections();
+    void onGenerationComplete_updatesCloseButton();
+    void onGenerationComplete_emitsAudiobookReadyRequest();
 
 private:
-    TestQueryWorker *m_worker{};
-    LibraryService  *m_libraryService{};
+    TestQueryWorker     *m_worker{};
+    LibraryService      *m_libraryService{};
     AudiobookFlowDialog *m_dialog{};
-
-    void populateTestData();
 };
 
 void AudiobookFlowDialogTest::init()
@@ -60,111 +61,190 @@ void AudiobookFlowDialogTest::init()
 
 void AudiobookFlowDialogTest::cleanup()
 {
-    delete m_dialog;
-    m_dialog = nullptr;
-    delete m_libraryService;
-    m_libraryService = nullptr;
-    delete m_worker;
-    m_worker = nullptr;
+    delete m_dialog;    m_dialog        = nullptr;
+    delete m_libraryService; m_libraryService = nullptr;
+    delete m_worker;    m_worker         = nullptr;
 }
 
-void AudiobookFlowDialogTest::construction_createsDialog()
+// ---------------------------------------------------------------------------
+
+void AudiobookFlowDialogTest::construction_isModalAtStep0_backHidden()
 {
-    QVERIFY(m_dialog != nullptr);
-    // Dialog should be modal (ApplicationModal by default)
     QVERIFY(m_dialog->windowModality() != Qt::NonModal);
+    QCOMPARE(m_dialog->m_currentStep, 0);
+    QVERIFY(m_dialog->m_backBtn->isHidden());
 }
 
-void AudiobookFlowDialogTest::startForBook_setsBookId()
+void AudiobookFlowDialogTest::backNavigation_clampedAtStep0()
 {
-    const QString bookId = QStringLiteral("gutenberg:1342");
-    m_dialog->startForBook(bookId);
-    // After starting, the dialog should load book details
-    // We can't directly assert the internal state, but we verify no crash
-    QVERIFY(m_dialog != nullptr);
-}
-
-void AudiobookFlowDialogTest::dialog_initializes_at_step1()
-{
-    // Dialog starts at step 1 (language selection)
-    // This is implicitly verified by the dialog being constructible
-    QVERIFY(m_dialog != nullptr);
-}
-
-void AudiobookFlowDialogTest::languageSelection_populatesLanguages()
-{
-    // When startForBook is called, languages should be queried
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // The dialog should have a language list populated
-    // We verify the dialog doesn't crash during language population
-    QVERIFY(m_dialog != nullptr);
-}
-
-void AudiobookFlowDialogTest::languageSelection_canSelectLanguage()
-{
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // Dialog should support language selection without crashing
-    QVERIFY(m_dialog != nullptr);
-}
-
-void AudiobookFlowDialogTest::formatSelection_populatesFormats()
-{
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // After language selection, formats should be populated
-    QVERIFY(m_dialog != nullptr);
-}
-
-void AudiobookFlowDialogTest::formatSelection_selectsFormat()
-{
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // Dialog should support format selection
-    QVERIFY(m_dialog != nullptr);
-}
-
-void AudiobookFlowDialogTest::voiceSelection_populatesVoices()
-{
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // Dialog should query and populate voices
-    QVERIFY(m_dialog != nullptr);
-}
-
-void AudiobookFlowDialogTest::voiceSelection_emitsSignalOnChange()
-{
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // Dialog should emit signal when voice selection changes
-    // This is tested by verifying no crash occurs
-    QVERIFY(m_dialog != nullptr);
-}
-
-void AudiobookFlowDialogTest::voiceSelection_supportsPresetAndCustom()
-{
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // Dialog's VoiceSelectorWidget should display both preset and custom voices
-    QVERIFY(m_dialog != nullptr);
+    m_dialog->onBackClicked();
+    QCOMPARE(m_dialog->m_currentStep, 0);
+    QVERIFY(m_dialog->m_backBtn->isHidden());
 }
 
 void AudiobookFlowDialogTest::backNavigation_decrementsStep()
 {
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // Dialog should support back button without crashing
-    QVERIFY(m_dialog != nullptr);
+    // Two-edition book shows a language step at step 0.
+    m_dialog->m_pendingDetailsId = 1;
+    BookDetails details;
+    details.editions.append({1, QStringLiteral("en")});
+    details.editions.append({2, QStringLiteral("fr")});
+    m_dialog->onDetailsCompleted(1, details);
+    QCOMPARE(m_dialog->m_currentStep, 0);
+    QVERIFY(m_dialog->m_backBtn->isHidden());
+
+    m_dialog->onNextOrGenerateClicked();
+    QCOMPARE(m_dialog->m_currentStep, 1);
+    QVERIFY(!m_dialog->m_backBtn->isHidden());
+
+    m_dialog->onBackClicked();
+    QCOMPARE(m_dialog->m_currentStep, 0);
+    QVERIFY(m_dialog->m_backBtn->isHidden());
 }
 
 void AudiobookFlowDialogTest::nextNavigation_incrementsStep()
 {
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // Dialog should support next button without crashing
-    QVERIFY(m_dialog != nullptr);
+    m_dialog->m_pendingDetailsId = 2;
+    BookDetails details;
+    details.editions.append({1, QStringLiteral("en")});
+    m_dialog->onDetailsCompleted(2, details);
+
+    QList<BookFormatEntry> formats;
+    BookFormatEntry epub; epub.formatType = QStringLiteral("epub");
+    formats.append(epub);
+    m_dialog->m_pendingFormatsId = 3;
+    m_dialog->onFormatsCompleted(3, formats);
+
+    m_dialog->onNextOrGenerateClicked();
+    QCOMPARE(m_dialog->m_currentStep, 1);
+    QVERIFY(!m_dialog->m_backBtn->isHidden());
 }
 
-void AudiobookFlowDialogTest::nextButton_requiresSelectionsPerStep()
+void AudiobookFlowDialogTest::singleEdition_autoSelectsLanguage()
 {
-    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
-    // Dialog should enforce selection requirements per step
-    QVERIFY(m_dialog != nullptr);
+    m_dialog->m_pendingDetailsId = 5;
+    BookDetails details;
+    details.editions.append({1, QStringLiteral("en")});
+    m_dialog->onDetailsCompleted(5, details);
+
+    QCOMPARE(m_dialog->m_hasLanguageStep, false);
+    QCOMPARE(m_dialog->m_selectedLanguage, QStringLiteral("en"));
+}
+
+void AudiobookFlowDialogTest::multipleEditions_requiresLanguageStep()
+{
+    m_dialog->m_pendingDetailsId = 6;
+    BookDetails details;
+    details.editions.append({1, QStringLiteral("en")});
+    details.editions.append({2, QStringLiteral("fr")});
+    m_dialog->onDetailsCompleted(6, details);
+
+    QCOMPARE(m_dialog->m_hasLanguageStep, true);
+    QCOMPARE(m_dialog->m_languageList->count(), 2);
+}
+
+void AudiobookFlowDialogTest::staleDetailsRequest_isIgnored()
+{
+    m_dialog->m_pendingDetailsId = 7;
+    BookDetails details;
+    details.editions.append({1, QStringLiteral("en")});
+    m_dialog->onDetailsCompleted(6, details); // wrong ID
+    QVERIFY(m_dialog->m_editions.isEmpty());
+}
+
+void AudiobookFlowDialogTest::staleFormatsRequest_isIgnored()
+{
+    m_dialog->m_pendingFormatsId = 9;
+    QList<BookFormatEntry> formats;
+    BookFormatEntry epub; epub.formatType = QStringLiteral("epub");
+    formats.append(epub);
+    m_dialog->onFormatsCompleted(8, formats); // wrong ID
+    QVERIFY(m_dialog->m_formats.isEmpty());
+}
+
+void AudiobookFlowDialogTest::populateFormatList_autoSelectsEpub()
+{
+    QList<BookFormatEntry> formats;
+    BookFormatEntry epub; epub.formatType = QStringLiteral("epub");
+    BookFormatEntry txt;  txt.formatType  = QStringLiteral("txt");
+    formats.append(epub);
+    formats.append(txt);
+
+    m_dialog->m_pendingFormatsId = 4;
+    m_dialog->onFormatsCompleted(4, formats);
+
+    QCOMPARE(m_dialog->m_selectedFormat, QStringLiteral("epub"));
+    QCOMPARE(m_dialog->m_formatList->count(), 2);
+    QVERIFY(m_dialog->m_formatList->item(0)->text().contains(QStringLiteral("recommended")));
+}
+
+void AudiobookFlowDialogTest::populateFormatList_selectsFirstWhenNoEpub()
+{
+    QList<BookFormatEntry> formats;
+    BookFormatEntry txt; txt.formatType = QStringLiteral("txt");
+    BookFormatEntry pdf; pdf.formatType = QStringLiteral("pdf");
+    formats.append(txt);
+    formats.append(pdf);
+
+    m_dialog->m_pendingFormatsId = 5;
+    m_dialog->onFormatsCompleted(5, formats);
+
+    QCOMPARE(m_dialog->m_selectedFormat, QStringLiteral("txt"));
+    QCOMPARE(m_dialog->m_formatList->count(), 2);
+}
+
+void AudiobookFlowDialogTest::voiceSelector_displaysPresetAndCustomSeparately()
+{
+    QList<VoiceEntry> voices;
+    voices.append({1, QStringLiteral("Classic Storyteller"), true});
+    voices.append({2, QStringLiteral("Warm Listener"), true});
+    voices.append({3, QStringLiteral("My Voice"), false});
+
+    m_dialog->m_voiceSelector->setVoices(voices);
+
+    // VoiceSelectorWidget has two QListWidgets: preset list first, custom second.
+    const auto lists = m_dialog->m_voiceSelector->findChildren<QListWidget *>();
+    QCOMPARE(lists.size(), 2);
+    QCOMPARE(lists[0]->count(), 2); // preset
+    QCOMPARE(lists[1]->count(), 1); // custom
+}
+
+void AudiobookFlowDialogTest::startGeneration_succeedsWithAllSelections()
+{
+    m_dialog->m_selectedLanguage  = QStringLiteral("en");
+    m_dialog->m_selectedFormat    = QStringLiteral("epub");
+    m_dialog->m_selectedVoiceId   = 1;
+    m_dialog->m_selectedVoiceName = QStringLiteral("Classic Storyteller");
+    m_dialog->m_currentStep       = 4;
+
+    m_dialog->onNextOrGenerateClicked();
+
+    QCOMPARE(m_dialog->m_progressBar->value(), 100);
+    QCOMPARE(m_dialog->m_nextBtn->text(), QStringLiteral("Close"));
+}
+
+void AudiobookFlowDialogTest::onGenerationComplete_updatesCloseButton()
+{
+    m_dialog->onGenerationComplete();
+
+    QCOMPARE(m_dialog->m_nextBtn->text(), QStringLiteral("Close"));
+    QVERIFY(!m_dialog->m_resultLabel->text().isEmpty());
+}
+
+void AudiobookFlowDialogTest::onGenerationComplete_emitsAudiobookReadyRequest()
+{
+    m_dialog->m_bookId        = QStringLiteral("gutenberg:1342");
+    m_dialog->m_libraryItemId = 1; // non-zero triggers the status update path
+
+    QSignalSpy spy(m_libraryService, &LibraryService::setAudiobookReadyRequested);
+    m_dialog->onGenerationComplete();
+
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(spy.at(0).at(1).toString(), QStringLiteral("gutenberg:1342"));
 }
 
 } // namespace bookhub::gui
 
-QTEST_MAIN(bookhub::gui::AudiobookFlowDialogTest)
+using AudiobookFlowDialogTest = bookhub::gui::AudiobookFlowDialogTest;
+QTEST_MAIN(AudiobookFlowDialogTest)
 #include "test_audiobook_flow_dialog.moc"

--- a/tests/gui/test_audiobook_flow_dialog.cpp
+++ b/tests/gui/test_audiobook_flow_dialog.cpp
@@ -50,6 +50,12 @@ private slots:
     void onGenerationComplete_updatesCloseButton();
     void onAddToLibraryClicked_emitsAudiobookReadyRequest();
 
+    // Dialog reuse: Next button must return to navigation mode after generation.
+    void resetState_rewiresToNextFromClose_afterGeneration();
+
+    // Generation complete with book not in library: "Add to library" stays hidden.
+    void onGenerationComplete_hidesAddToLibBtn_whenNotInLibrary();
+
     // End-to-end: details/formats flow through the real worker chain. Would
     // regress if the dialog stops calling BookDetailsService::connectToWorker.
     void startForBook_populatesLanguagesThroughWorkerChain();
@@ -274,6 +280,41 @@ void AudiobookFlowDialogTest::onAddToLibraryClicked_emitsAudiobookReadyRequest()
     m_dialog->onAddToLibraryClicked(); // explicit user action triggers the write
     QCOMPARE(spy.count(), 1);
     QCOMPARE(spy.at(0).at(1).toString(), QStringLiteral("gutenberg:1342"));
+}
+
+void AudiobookFlowDialogTest::resetState_rewiresToNextFromClose_afterGeneration()
+{
+    // Drive to completion — onGenerationComplete() rewires Next to accept().
+    m_dialog->m_selectedLanguage  = QStringLiteral("en");
+    m_dialog->m_selectedFormat    = QStringLiteral("epub");
+    m_dialog->m_selectedVoiceId   = 1;
+    m_dialog->m_selectedVoiceName = QStringLiteral("Classic Storyteller");
+    m_dialog->m_currentStep       = 4;
+    m_dialog->onNextOrGenerateClicked();
+    QCOMPARE(m_dialog->m_nextBtn->text(), QStringLiteral("Close"));
+
+    // Reopen for a second book — resetState() must rewire Next back to navigation.
+    m_dialog->resetState();
+    QCOMPARE(m_dialog->m_nextBtn->text(), QStringLiteral("Next →"));
+    QCOMPARE(m_dialog->m_currentStep, 0);
+
+    // Verify the step actually advances on click rather than accepting the dialog.
+    m_dialog->m_selectedLanguage = QStringLiteral("en");
+    m_dialog->m_hasLanguageStep  = true;
+    m_dialog->updateStepUi();
+    m_dialog->onNextOrGenerateClicked();
+    QCOMPARE(m_dialog->m_currentStep, 1);
+}
+
+void AudiobookFlowDialogTest::onGenerationComplete_hidesAddToLibBtn_whenNotInLibrary()
+{
+    m_dialog->m_libraryItemId = 0; // book not in the user's library
+    m_dialog->onGenerationComplete();
+
+    QVERIFY(m_dialog->m_addToLibBtn->isHidden());
+    // Open-file and result label are still shown regardless of library membership.
+    QVERIFY(!m_dialog->m_openFileBtn->isHidden());
+    QVERIFY(!m_dialog->m_resultLabel->text().isEmpty());
 }
 
 void AudiobookFlowDialogTest::startForBook_populatesLanguagesThroughWorkerChain()

--- a/tests/gui/test_audiobook_flow_dialog.cpp
+++ b/tests/gui/test_audiobook_flow_dialog.cpp
@@ -108,10 +108,12 @@ void AudiobookFlowDialogTest::backNavigation_decrementsStep()
 
 void AudiobookFlowDialogTest::nextNavigation_incrementsStep()
 {
+    // Single-edition book: language auto-selected, dialog opens at step 1 (format).
     m_dialog->m_pendingDetailsId = 2;
     BookDetails details;
     details.editions.append({1, QStringLiteral("en")});
     m_dialog->onDetailsCompleted(2, details);
+    QCOMPARE(m_dialog->m_currentStep, 1); // skipped language step
 
     QList<BookFormatEntry> formats;
     BookFormatEntry epub; epub.formatType = QStringLiteral("epub");
@@ -120,7 +122,7 @@ void AudiobookFlowDialogTest::nextNavigation_incrementsStep()
     m_dialog->onFormatsCompleted(3, formats);
 
     m_dialog->onNextOrGenerateClicked();
-    QCOMPARE(m_dialog->m_currentStep, 1);
+    QCOMPARE(m_dialog->m_currentStep, 2); // advanced to voice selection
     QVERIFY(!m_dialog->m_backBtn->isHidden());
 }
 
@@ -133,6 +135,7 @@ void AudiobookFlowDialogTest::singleEdition_autoSelectsLanguage()
 
     QCOMPARE(m_dialog->m_hasLanguageStep, false);
     QCOMPARE(m_dialog->m_selectedLanguage, QStringLiteral("en"));
+    QCOMPARE(m_dialog->m_currentStep, 1); // dialog skips to format step
 }
 
 void AudiobookFlowDialogTest::multipleEditions_requiresLanguageStep()

--- a/tests/gui/test_audiobook_flow_dialog.cpp
+++ b/tests/gui/test_audiobook_flow_dialog.cpp
@@ -1,9 +1,12 @@
 #include <QtTest>
+#include <QApplication>
 #include <QLabel>
 #include <QListWidget>
+#include <QMessageBox>
 #include <QProgressBar>
 #include <QPushButton>
 #include <QSignalSpy>
+#include <QTimer>
 
 #include "gui/dialogs/audiobook_flow_dialog.h"
 #include "gui/services/library_service.h"
@@ -42,8 +45,9 @@ private slots:
 
     // Generation flow
     void startGeneration_succeedsWithAllSelections();
+    void startGeneration_failsWithMissingSelections();
     void onGenerationComplete_updatesCloseButton();
-    void onGenerationComplete_emitsAudiobookReadyRequest();
+    void onAddToLibraryClicked_emitsAudiobookReadyRequest();
 
 private:
     TestQueryWorker     *m_worker{};
@@ -164,18 +168,19 @@ void AudiobookFlowDialogTest::staleFormatsRequest_isIgnored()
 
 void AudiobookFlowDialogTest::populateFormatList_autoSelectsEpub()
 {
+    // txt is first so the test verifies epub is preferred, not just "selects first"
     QList<BookFormatEntry> formats;
-    BookFormatEntry epub; epub.formatType = QStringLiteral("epub");
     BookFormatEntry txt;  txt.formatType  = QStringLiteral("txt");
-    formats.append(epub);
+    BookFormatEntry epub; epub.formatType = QStringLiteral("epub");
     formats.append(txt);
+    formats.append(epub);
 
     m_dialog->m_pendingFormatsId = 4;
     m_dialog->onFormatsCompleted(4, formats);
 
     QCOMPARE(m_dialog->m_selectedFormat, QStringLiteral("epub"));
     QCOMPARE(m_dialog->m_formatList->count(), 2);
-    QVERIFY(m_dialog->m_formatList->item(0)->text().contains(QStringLiteral("recommended")));
+    QVERIFY(m_dialog->m_formatList->item(1)->text().contains(QStringLiteral("recommended")));
 }
 
 void AudiobookFlowDialogTest::populateFormatList_selectsFirstWhenNoEpub()
@@ -223,6 +228,24 @@ void AudiobookFlowDialogTest::startGeneration_succeedsWithAllSelections()
     QCOMPARE(m_dialog->m_nextBtn->text(), QStringLiteral("Close"));
 }
 
+void AudiobookFlowDialogTest::startGeneration_failsWithMissingSelections()
+{
+    // Leave language, format, and voice unset so startGeneration() rejects.
+    m_dialog->m_currentStep = 4;
+
+    // Dismiss the warning dialog that showErrorState() will block on.
+    QTimer::singleShot(0, [] {
+        auto *box = qobject_cast<QMessageBox *>(QApplication::activeModalWidget());
+        if (box) box->reject();
+    });
+
+    m_dialog->onNextOrGenerateClicked();
+
+    // Generation was blocked — progress bar stays at 0 and result is empty.
+    QCOMPARE(m_dialog->m_progressBar->value(), 0);
+    QVERIFY(m_dialog->m_resultLabel->text().isEmpty());
+}
+
 void AudiobookFlowDialogTest::onGenerationComplete_updatesCloseButton()
 {
     m_dialog->onGenerationComplete();
@@ -231,14 +254,16 @@ void AudiobookFlowDialogTest::onGenerationComplete_updatesCloseButton()
     QVERIFY(!m_dialog->m_resultLabel->text().isEmpty());
 }
 
-void AudiobookFlowDialogTest::onGenerationComplete_emitsAudiobookReadyRequest()
+void AudiobookFlowDialogTest::onAddToLibraryClicked_emitsAudiobookReadyRequest()
 {
     m_dialog->m_bookId        = QStringLiteral("gutenberg:1342");
     m_dialog->m_libraryItemId = 1; // non-zero triggers the status update path
 
     QSignalSpy spy(m_libraryService, &LibraryService::setAudiobookReadyRequested);
-    m_dialog->onGenerationComplete();
+    m_dialog->onGenerationComplete(); // shows "Add to library" button — no status write
+    QCOMPARE(spy.count(), 0);
 
+    m_dialog->onAddToLibraryClicked(); // explicit user action triggers the write
     QCOMPARE(spy.count(), 1);
     QCOMPARE(spy.at(0).at(1).toString(), QStringLiteral("gutenberg:1342"));
 }

--- a/tests/gui/test_audiobook_flow_dialog.cpp
+++ b/tests/gui/test_audiobook_flow_dialog.cpp
@@ -1,0 +1,170 @@
+#include <QtTest>
+#include <QLabel>
+#include <QListWidget>
+#include <QPushButton>
+#include <QComboBox>
+
+#include "gui/dialogs/audiobook_flow_dialog.h"
+#include "gui/services/library_service.h"
+#include "gui/widgets/step_indicator_widget.h"
+#include "gui/widgets/voice_selector_widget.h"
+#include "support/test_query_worker.h"
+
+namespace bookhub::gui {
+
+class AudiobookFlowDialogTest : public QObject {
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+
+    // Construction and dialog lifecycle
+    void construction_createsDialog();
+    void startForBook_setsBookId();
+    void dialog_initializes_at_step1();
+
+    // Language selection (Step 1)
+    void languageSelection_populatesLanguages();
+    void languageSelection_canSelectLanguage();
+
+    // Format selection (Step 2)
+    void formatSelection_populatesFormats();
+    void formatSelection_selectsFormat();
+
+    // Voice selection (Step 3)
+    void voiceSelection_populatesVoices();
+    void voiceSelection_emitsSignalOnChange();
+    void voiceSelection_supportsPresetAndCustom();
+
+    // Navigation
+    void backNavigation_decrementsStep();
+    void nextNavigation_incrementsStep();
+    void nextButton_requiresSelectionsPerStep();
+
+private:
+    TestQueryWorker *m_worker{};
+    LibraryService  *m_libraryService{};
+    AudiobookFlowDialog *m_dialog{};
+
+    void populateTestData();
+};
+
+void AudiobookFlowDialogTest::init()
+{
+    m_worker = new TestQueryWorker();
+    m_libraryService = new LibraryService();
+    m_libraryService->connectToWorker(m_worker);
+    m_dialog = new AudiobookFlowDialog(m_libraryService, m_worker);
+}
+
+void AudiobookFlowDialogTest::cleanup()
+{
+    delete m_dialog;
+    m_dialog = nullptr;
+    delete m_libraryService;
+    m_libraryService = nullptr;
+    delete m_worker;
+    m_worker = nullptr;
+}
+
+void AudiobookFlowDialogTest::construction_createsDialog()
+{
+    QVERIFY(m_dialog != nullptr);
+    // Dialog should be modal (ApplicationModal by default)
+    QVERIFY(m_dialog->windowModality() != Qt::NonModal);
+}
+
+void AudiobookFlowDialogTest::startForBook_setsBookId()
+{
+    const QString bookId = QStringLiteral("gutenberg:1342");
+    m_dialog->startForBook(bookId);
+    // After starting, the dialog should load book details
+    // We can't directly assert the internal state, but we verify no crash
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::dialog_initializes_at_step1()
+{
+    // Dialog starts at step 1 (language selection)
+    // This is implicitly verified by the dialog being constructible
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::languageSelection_populatesLanguages()
+{
+    // When startForBook is called, languages should be queried
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // The dialog should have a language list populated
+    // We verify the dialog doesn't crash during language population
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::languageSelection_canSelectLanguage()
+{
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // Dialog should support language selection without crashing
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::formatSelection_populatesFormats()
+{
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // After language selection, formats should be populated
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::formatSelection_selectsFormat()
+{
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // Dialog should support format selection
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::voiceSelection_populatesVoices()
+{
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // Dialog should query and populate voices
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::voiceSelection_emitsSignalOnChange()
+{
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // Dialog should emit signal when voice selection changes
+    // This is tested by verifying no crash occurs
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::voiceSelection_supportsPresetAndCustom()
+{
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // Dialog's VoiceSelectorWidget should display both preset and custom voices
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::backNavigation_decrementsStep()
+{
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // Dialog should support back button without crashing
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::nextNavigation_incrementsStep()
+{
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // Dialog should support next button without crashing
+    QVERIFY(m_dialog != nullptr);
+}
+
+void AudiobookFlowDialogTest::nextButton_requiresSelectionsPerStep()
+{
+    m_dialog->startForBook(QStringLiteral("gutenberg:1342"));
+    // Dialog should enforce selection requirements per step
+    QVERIFY(m_dialog != nullptr);
+}
+
+} // namespace bookhub::gui
+
+QTEST_MAIN(bookhub::gui::AudiobookFlowDialogTest)
+#include "test_audiobook_flow_dialog.moc"

--- a/tests/gui/test_audiobook_flow_dialog.cpp
+++ b/tests/gui/test_audiobook_flow_dialog.cpp
@@ -11,6 +11,7 @@
 #include "gui/dialogs/audiobook_flow_dialog.h"
 #include "gui/services/library_service.h"
 #include "gui/widgets/voice_selector_widget.h"
+#include "support/test_database_utils.h"
 #include "support/test_query_worker.h"
 
 namespace bookhub::gui {
@@ -48,6 +49,10 @@ private slots:
     void startGeneration_failsWithMissingSelections();
     void onGenerationComplete_updatesCloseButton();
     void onAddToLibraryClicked_emitsAudiobookReadyRequest();
+
+    // End-to-end: details/formats flow through the real worker chain. Would
+    // regress if the dialog stops calling BookDetailsService::connectToWorker.
+    void startForBook_populatesLanguagesThroughWorkerChain();
 
 private:
     TestQueryWorker     *m_worker{};
@@ -269,6 +274,30 @@ void AudiobookFlowDialogTest::onAddToLibraryClicked_emitsAudiobookReadyRequest()
     m_dialog->onAddToLibraryClicked(); // explicit user action triggers the write
     QCOMPARE(spy.count(), 1);
     QCOMPARE(spy.at(0).at(1).toString(), QStringLiteral("gutenberg:1342"));
+}
+
+void AudiobookFlowDialogTest::startForBook_populatesLanguagesThroughWorkerChain()
+{
+    // Tear down the dialog from init() — we need a fresh one constructed
+    // *after* the default-connection schema is open so its BookDetailsService
+    // can resolve real DB rows through the worker chain.
+    delete m_dialog;
+    m_dialog = nullptr;
+
+    bookhub::tests::TestDatabase testDb;
+    QVERIFY(testDb.open()); // opens default connection
+    QVERIFY(testDb.createSchema());
+    QVERIFY(testDb.insertSampleData());
+
+    AudiobookFlowDialog dialog(m_libraryService, m_worker);
+    dialog.startForBook(QStringLiteral("lccn:n78095332")); // 2 editions in sample data
+
+    // If BookDetailsService is not wired to the worker, the chain produces
+    // nothing and m_editions stays empty. With wiring, the synchronous
+    // TestQueryWorker dispatch fully populates the language list.
+    QCOMPARE(dialog.m_editions.size(), 2);
+    QCOMPARE(dialog.m_languageList->count(), 2);
+    QVERIFY(dialog.m_hasLanguageStep);
 }
 
 } // namespace bookhub::gui

--- a/tests/support/test_query_worker.h
+++ b/tests/support/test_query_worker.h
@@ -131,34 +131,43 @@ public slots:
 
     void handleListVoicesRequest(quint64 requestId) override
     {
-        QueryWorker::handleListVoicesRequest(requestId);
+        emit listVoicesCompleted(requestId,
+            internal::listVoices(QSqlDatabase::defaultConnection));
     }
 
     void handleInsertVoiceRequest(quint64 requestId, const QString &voiceName,
                                   const QString &voiceType, bool isPreset) override
     {
-        QueryWorker::handleInsertVoiceRequest(requestId, voiceName, voiceType, isPreset);
+        int newId = -1;
+        const bool ok = internal::insertVoice(voiceName, voiceType, isPreset,
+                                               &newId, QSqlDatabase::defaultConnection);
+        emit insertVoiceCompleted(requestId, ok, newId);
     }
 
     void handleUpdateVoiceRequest(quint64 requestId, int voiceId,
                                   const QString &voiceType) override
     {
-        QueryWorker::handleUpdateVoiceRequest(requestId, voiceId, voiceType);
+        emit updateVoiceCompleted(requestId,
+            internal::updateVoice(voiceId, voiceType, QSqlDatabase::defaultConnection));
     }
 
     void handleDeleteVoiceRequest(quint64 requestId, int voiceId) override
     {
-        QueryWorker::handleDeleteVoiceRequest(requestId, voiceId);
+        emit deleteVoiceCompleted(requestId,
+            internal::deleteVoice(voiceId, QSqlDatabase::defaultConnection));
     }
 
     void handleQueryAudiobookStatusRequest(quint64 requestId, const QString &bookId) override
     {
-        QueryWorker::handleQueryAudiobookStatusRequest(requestId, bookId);
+        bool isReady = false;
+        internal::queryAudiobookStatus(bookId, isReady, QSqlDatabase::defaultConnection);
+        emit audiobookStatusQueried(requestId, isReady);
     }
 
     void handleSetAudiobookReadyRequest(quint64 requestId, const QString &bookId) override
     {
-        QueryWorker::handleSetAudiobookReadyRequest(requestId, bookId);
+        const bool success = internal::setAudiobookReady(bookId, QSqlDatabase::defaultConnection);
+        emit audiobookReadySet(requestId, success);
     }
 };
 

--- a/tests/support/test_query_worker.h
+++ b/tests/support/test_query_worker.h
@@ -135,20 +135,20 @@ public slots:
             internal::listVoices(QSqlDatabase::defaultConnection));
     }
 
-    void handleInsertVoiceRequest(quint64 requestId, const QString &voiceName,
-                                  const QString &voiceType, bool isPreset) override
+    void handleInsertVoiceRequest(quint64 requestId, const QString &name,
+                                  const QString &type, const QString &engine) override
     {
         int newId = -1;
-        const bool ok = internal::insertVoice(voiceName, voiceType, isPreset,
+        const bool ok = internal::insertVoice(name, type, engine,
                                                &newId, QSqlDatabase::defaultConnection);
         emit insertVoiceCompleted(requestId, ok, newId);
     }
 
     void handleUpdateVoiceRequest(quint64 requestId, int voiceId,
-                                  const QString &voiceType) override
+                                  const QString &engine) override
     {
         emit updateVoiceCompleted(requestId,
-            internal::updateVoice(voiceId, voiceType, QSqlDatabase::defaultConnection));
+            internal::updateVoice(voiceId, engine, QSqlDatabase::defaultConnection));
     }
 
     void handleDeleteVoiceRequest(quint64 requestId, int voiceId) override

--- a/tests/support/test_query_worker.h
+++ b/tests/support/test_query_worker.h
@@ -128,6 +128,38 @@ public slots:
             internal::fetchFormatsForEdition(editionId,
                                              QSqlDatabase::defaultConnection));
     }
+
+    void handleListVoicesRequest(quint64 requestId) override
+    {
+        QueryWorker::handleListVoicesRequest(requestId);
+    }
+
+    void handleInsertVoiceRequest(quint64 requestId, const QString &voiceName,
+                                  const QString &voiceType, bool isPreset) override
+    {
+        QueryWorker::handleInsertVoiceRequest(requestId, voiceName, voiceType, isPreset);
+    }
+
+    void handleUpdateVoiceRequest(quint64 requestId, int voiceId,
+                                  const QString &voiceType) override
+    {
+        QueryWorker::handleUpdateVoiceRequest(requestId, voiceId, voiceType);
+    }
+
+    void handleDeleteVoiceRequest(quint64 requestId, int voiceId) override
+    {
+        QueryWorker::handleDeleteVoiceRequest(requestId, voiceId);
+    }
+
+    void handleQueryAudiobookStatusRequest(quint64 requestId, const QString &bookId) override
+    {
+        QueryWorker::handleQueryAudiobookStatusRequest(requestId, bookId);
+    }
+
+    void handleSetAudiobookReadyRequest(quint64 requestId, const QString &bookId) override
+    {
+        QueryWorker::handleSetAudiobookReadyRequest(requestId, bookId);
+    }
 };
 
 } // namespace bookhub::gui

--- a/tests/support/test_query_worker.h
+++ b/tests/support/test_query_worker.h
@@ -5,6 +5,7 @@
 #include "gui/services/explore_service.h"
 #include "gui/services/library_service.h"
 #include "gui/services/search_service.h"
+#include "gui/services/tts_service.h"
 
 #include <QSqlDatabase>
 

--- a/tests/support/test_query_worker.h
+++ b/tests/support/test_query_worker.h
@@ -5,7 +5,6 @@
 #include "gui/services/explore_service.h"
 #include "gui/services/library_service.h"
 #include "gui/services/search_service.h"
-#include "gui/services/tts_service.h"
 
 #include <QSqlDatabase>
 

--- a/tools/migrate_db.py
+++ b/tools/migrate_db.py
@@ -104,7 +104,7 @@ CREATE TABLE IF NOT EXISTS library_items (
     book_id TEXT NOT NULL UNIQUE,
     edition_id INTEGER,
     added_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    status TEXT,
+    status TEXT CHECK(status IS NULL OR status IN ('saved', 'downloading', 'downloaded', 'converting', 'audiobook_ready', 'error')),
     FOREIGN KEY (book_id) REFERENCES books(book_id) ON DELETE CASCADE ON UPDATE CASCADE,
     FOREIGN KEY (edition_id) REFERENCES editions(id)
 )

--- a/tools/migrate_db.py
+++ b/tools/migrate_db.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 """
-migrate_db.py — Migrate bookhub.db from schema version 0 to version 1.
+migrate_db.py — Migrate bookhub.db to the current schema version.
 
 Schema v0: ISBN-keyed books table.
 Schema v1: book_id-keyed books table with book_identifiers for cross-source deduplication.
+Schema v2: Adds download-flow tables and library_items.status values.
+Schema v3: Adds voices table (preset/custom TTS voices) and a CHECK constraint on
+           library_items.status to prevent invalid state values.
 
-All migration steps run inside a single transaction. PRAGMA user_version is set
-outside the transaction (SQLite requirement). On any failure the transaction is
+The v1→v2 migration is handled automatically by the app at startup.
+All other migration steps run inside a single transaction. PRAGMA user_version is
+set outside the transaction (SQLite requirement). On any failure the transaction is
 rolled back and the database is left untouched.
 """
 
@@ -111,6 +115,29 @@ CREATE TABLE IF NOT EXISTS library_items (
 """
 
 # ---------------------------------------------------------------------------
+# New schema DDL (version 3)
+# ---------------------------------------------------------------------------
+
+NEW_VOICES_DDL = """
+CREATE TABLE IF NOT EXISTS voices (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name                 TEXT NOT NULL UNIQUE,
+    type                 TEXT NOT NULL CHECK(type IN ('preset', 'custom')),
+    engine               TEXT NOT NULL CHECK(engine IN ('sherpa_onnx', 'pocket_tts')),
+    model_path           TEXT,
+    config_path          TEXT,
+    reference_audio_path TEXT,
+    created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+"""
+
+_PRESET_VOICES = [
+    ("Classic Storyteller", "preset", "sherpa_onnx"),
+    ("Warm Listener",       "preset", "sherpa_onnx"),
+    ("Crisp Narrator",      "preset", "sherpa_onnx"),
+]
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -143,6 +170,77 @@ def column_exists(cur: sqlite3.Cursor, table: str, column: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# v2 → v3 migration
+# ---------------------------------------------------------------------------
+
+def _migrate_v2_to_v3(con: sqlite3.Connection, cur: sqlite3.Cursor) -> None:
+    """Migrate an open v2 database to v3 in-place.
+
+    Changes:
+      - Creates the ``voices`` table for preset and custom TTS voices.
+      - Seeds the three built-in preset voices (idempotent via INSERT OR IGNORE).
+      - Recreates ``library_items`` with a CHECK constraint on ``status`` so
+        invalid values are rejected at the DB level.  SQLite does not support
+        ALTER TABLE ADD CONSTRAINT, so the rename-and-copy pattern is used.
+    """
+    print("Migrating schema v2 → v3 ...")
+
+    # PRAGMA must run outside a transaction.
+    con.execute("PRAGMA foreign_keys = OFF")
+    con.execute("BEGIN")
+
+    # Create voices table (safe to re-run; IF NOT EXISTS).
+    con.execute(NEW_VOICES_DDL)
+
+    # Seed preset voices. UNIQUE(name) makes this idempotent.
+    con.executemany(
+        "INSERT OR IGNORE INTO voices (name, type, engine) VALUES (?, ?, ?)",
+        _PRESET_VOICES,
+    )
+    print(f"Seeded {len(_PRESET_VOICES)} preset voices")
+
+    # Recreate library_items with CHECK constraint on status.
+    # INSERT ... SELECT fails loudly if any existing row violates the new
+    # constraint — better than silently discarding data.
+    con.execute("""
+        CREATE TABLE library_items_new (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            book_id    TEXT NOT NULL UNIQUE,
+            edition_id INTEGER,
+            added_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            status TEXT CHECK(status IS NULL OR status IN
+                ('saved', 'downloading', 'downloaded',
+                 'converting', 'audiobook_ready', 'error')),
+            FOREIGN KEY (book_id)    REFERENCES books(book_id)
+                ON DELETE CASCADE ON UPDATE CASCADE,
+            FOREIGN KEY (edition_id) REFERENCES editions(id)
+        )
+    """)
+    cur.execute("SELECT COUNT(*) FROM library_items")
+    item_count = cur.fetchone()[0]
+    con.execute("INSERT INTO library_items_new SELECT * FROM library_items")
+    con.execute("DROP TABLE library_items")
+    con.execute("ALTER TABLE library_items_new RENAME TO library_items")
+    print(f"Migrated {item_count} library_items")
+
+    con.execute("COMMIT")
+    con.execute("PRAGMA foreign_keys = ON")
+
+    try:
+        con.execute("PRAGMA user_version = 3")
+    except Exception as exc:
+        print(
+            f"Error: migration committed but version stamp failed: {exc}\n"
+            "The schema is correct. Run the following to fix the version:\n"
+            "  sqlite3 bookhub.db 'PRAGMA user_version = 3'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Migration complete. user_version set to 3.")
+
+
+# ---------------------------------------------------------------------------
 # Migration
 # ---------------------------------------------------------------------------
 
@@ -169,8 +267,13 @@ def migrate(db_path: str) -> None:
             con.close()
             return
 
-        if user_version >= 2:
-            print("Already at version 2 (or newer), nothing to do.")
+        if user_version == 2:
+            _migrate_v2_to_v3(con, cur)
+            con.close()
+            return
+
+        if user_version >= 3:
+            print("Already at version 3 (current), nothing to do.")
             con.close()
             return
 
@@ -441,8 +544,9 @@ def main() -> None:
         )
     parser = argparse.ArgumentParser(
         description=(
-            "Migrate bookhub.db from schema version 0 (ISBN-keyed) "
-            "to version 1 (book_id-keyed). "
+            "Migrate bookhub.db to the current schema version (v3). "
+            "Handles v0→v1 (ISBN-keyed to book_id-keyed) and v2→v3 "
+            "(voices table + library_items CHECK constraint). "
             "The v1→v2 migration is handled automatically by the app at startup.\n\n"
             "Platform default paths:\n"
             "  Linux:   ~/.local/share/BookHub/BookHub/bookhub.db\n"


### PR DESCRIPTION
## Task 12: Audiobook Conversion Flow Implementation

Implements Issue #13 — audiobook generation workflow with a 5-step dialog, voice management scaffolding, and library integration.

### Overview
Users can now:
1. Select language for multi-language editions
2. Choose text format (txt, epub, html)
3. Select from preset voices
4. Preview the chosen voice (UI-only in MVP)
5. Trigger generation (UI-only in MVP — actual TTS deferred to Task 13)

### New Components

#### Dialogs & Widgets
- **AudiobookFlowDialog** — Main 5-step modal dialog controller
- **VoiceUploadDialog** — Custom voice recording upload with validation
- **VoiceSelectorWidget** — Organized preset/custom voice list
- **MiniAudioPlayerWidget** — Preview player with scrubber and time display

#### Backend Services
- **TTSService** — Abstract TTS provider interface (MVP placeholder, no concrete impl yet)
- **LibraryService** — New audiobook status query/update methods
- **QueryWorker** — Voice CRUD operations (list, insert, update, delete)

### Database Changes
- New `voices` table: `(id, name, type, engine, model_path, config_path, reference_audio_path, created_at)` with CHECK constraints on `type` ∈ `{preset, custom}` and `engine` ∈ `{sherpa_onnx, pocket_tts}`.
- `library_items.status` now carries a CHECK constraint listing the legal values, including the new `'audiobook_ready'` state. Migration v2→v3 recreates the table to apply the constraint to upgraded DBs.
- Schema migration: v2 → v3 with transaction + FK-toggle pattern matching the existing v1→v2 migration.
- Preset voices ("Classic Storyteller", "Warm Listener", "Crisp Narrator") seeded in `createSchema()` so production Release builds — which skip `insertSampleData` — have them available.

### Integration
- **BookDetailsPanel** — Audiobook button is now functional (enabled when formats are available).
- **MainWindow** — Hooks `AudiobookFlowDialog` to the panel signal.
- **LibraryScreen** — Shows ♪ audiobook ready status badge.
- **book_card_delegate.cpp** — Audiobook status display with music-note icon.

### Technical Details
- C++23 code style; clang-tidy clean.
- Voice CRUD wired through `QueryWorker` on the query thread.
- `BookDetailsService` is connected to the worker in the dialog constructor (the missing wiring caught in code review has been fixed).
- End-to-end test added that runs the dialog through the real worker chain so a future regression of that wiring would fail the suite.
- Per-step Next-button gating prevents reaching the generate step with empty fields.

### MVP Scope
- TTS service is placeholder — actual audio generation deferred to Task 13 (Sherpa-ONNX / PocketTTS).
- Custom voice upload: format check only; duration check deferred.
- Audio playback widgets are UI-scaffolded.

### Files Changed
- Created: 11 new files (dialogs, widgets, services, tests).
- Modified: source files for DB schema/migration, UI integration, query worker, build config.

### Testing
- 15 audiobook-flow test cases pass, including a new end-to-end test that exercises the dialog → BookDetailsService → QueryWorker → DB chain.
- Covers: dialog lifecycle, navigation, stale-id rejection, format auto-select, voice display, generation guard, and post-generation library write.

### Related Issue
Closes #13

### Next Steps
1. Task 13: Implement actual TTS generation (Sherpa-ONNX or PocketTTS).
2. Add audio playback to `MiniAudioPlayerWidget`.
3. Implement custom voice model training/registration.
