### PR TITLE
chore: bump GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v6.0.2
 
     - name: Cache apt packages
       uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
     - name: Upload build artifact
       if: success()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v7.0.1
       with:
         name: bookhub-${{ github.sha }}
         path: build/bookhub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
         shasum -a 256 "dist/${NAME}.dmg" > "dist/${NAME}.dmg.sha256"
 
     - name: Upload artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: release-${{ matrix.platform }}
         path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
 
     - name: Create GitHub Release
       # Pinned to v7 by SHA because this step runs JavaScript with GITHUB_TOKEN.
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout tag
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.ref }}
         # Full history is required so the "Verify tag is on master" step can


### PR DESCRIPTION
Merged Dependabot updates for GitHub Actions:\n\n- actions/download-artifact: 4.3.0 → 8.0.1\n- actions/checkout: 4.3.1 → 6.0.2\n- actions/upload-artifact: 4.6.2 → 7.0.1\n- actions/github-script: 7.1.0 → 9.0.0\n\nAll workflows verified to be compatible with these updates.